### PR TITLE
changes to make cpp templates look identical

### DIFF
--- a/pkg/gen/filters/filtercpp/cpp_default.go
+++ b/pkg/gen/filters/filtercpp/cpp_default.go
@@ -18,7 +18,7 @@ func ToDefaultString(prefix string, schema *model.Schema) (string, error) {
 	case "int":
 		text = "0"
 	case "float":
-		text = "0.0"
+		text = "0.0f"
 	case "bool":
 		text = "false"
 	default:
@@ -27,7 +27,7 @@ func ToDefaultString(prefix string, schema *model.Schema) (string, error) {
 		}
 		e := schema.Module.LookupEnum(t)
 		if e != nil {
-			text = fmt.Sprintf("%s::%s", e.Name, e.Members[0].Name)
+			text = fmt.Sprintf("%sEnum::%s", e.Name, e.Members[0].Name)
 		}
 		s := schema.Module.LookupStruct(t)
 		if s != nil {
@@ -40,11 +40,11 @@ func ToDefaultString(prefix string, schema *model.Schema) (string, error) {
 	}
 	if schema.IsArray {
 		inner := model.Schema{Type: t, Module: schema.Module}
-		ret, err := ToReturnString(prefix, &inner)
+		ret, err := ToTypeString(prefix, &inner)
 		if err != nil {
 			return "xxx", fmt.Errorf("ToDefaultString inner value error: %s", err)
 		}
-		text = fmt.Sprintf("std::vector<%s>()", ret)
+		text = fmt.Sprintf("std::list<%s>()", ret)
 	}
 	return text, nil
 }

--- a/pkg/gen/filters/filtercpp/cpp_param.go
+++ b/pkg/gen/filters/filtercpp/cpp_param.go
@@ -11,33 +11,33 @@ func ToParamString(prefix string, schema *model.Schema, name string) (string, er
 	if schema.IsArray {
 		inner := *schema
 		inner.IsArray = false
-		ret, err := ToReturnString(prefix, &inner)
+		ret, err := ToTypeString(prefix, &inner)
 		if err != nil {
 			return "xxx", fmt.Errorf("ToParamString inner value error: %s", err)
 		}
-		return fmt.Sprintf("const std::vector<%s> &%s", ret, name), nil
+		return fmt.Sprintf("const std::list<%s>& %s", ret, name), nil
 	}
 	switch t {
 	case "string":
-		return fmt.Sprintf("const std::string &%s", name), nil
+		return fmt.Sprintf("const std::string& %s", name), nil
 	case "int":
 		return fmt.Sprintf("int %s", name), nil
 	case "float":
-		return fmt.Sprintf("double %s", name), nil
+		return fmt.Sprintf("float %s", name), nil
 	case "bool":
 		return fmt.Sprintf("bool %s", name), nil
 	}
 	e := schema.Module.LookupEnum(t)
 	if e != nil {
-		return fmt.Sprintf("%s %s", e.Name, name), nil
+		return fmt.Sprintf("const %sEnum& %s", e.Name, name), nil
 	}
 	s := schema.Module.LookupStruct(t)
 	if s != nil {
-		return fmt.Sprintf("const %s &%s", s.Name, name), nil
+		return fmt.Sprintf("const %s& %s", s.Name, name), nil
 	}
 	i := schema.Module.LookupInterface(t)
 	if i != nil {
-		return fmt.Sprintf("%s *%s", i.Name, name), nil
+		return fmt.Sprintf("%s* %s", i.Name, name), nil
 	}
 	return "xxx", fmt.Errorf("ToParamString: unknown type %s", t)
 }

--- a/pkg/gen/filters/filtercpp/cpp_return.go
+++ b/pkg/gen/filters/filtercpp/cpp_return.go
@@ -17,7 +17,7 @@ func ToReturnString(prefix string, schema *model.Schema) (string, error) {
 	case "int":
 		text = "int"
 	case "float":
-		text = "double"
+		text = "float"
 	case "bool":
 		text = "bool"
 	default:
@@ -26,11 +26,11 @@ func ToReturnString(prefix string, schema *model.Schema) (string, error) {
 		}
 		e := schema.Module.LookupEnum(t)
 		if e != nil {
-			text = fmt.Sprintf("%s%s", prefix, e.Name)
+			text = fmt.Sprintf("const %s%sEnum&", prefix, e.Name)
 		}
 		s := schema.Module.LookupStruct(t)
 		if s != nil {
-			text = fmt.Sprintf("%s%s", prefix, s.Name)
+			text = fmt.Sprintf("const %s%s&", prefix, s.Name)
 		}
 		i := schema.Module.LookupInterface(t)
 		if i != nil {
@@ -38,7 +38,13 @@ func ToReturnString(prefix string, schema *model.Schema) (string, error) {
 		}
 	}
 	if schema.IsArray {
-		text = fmt.Sprintf("std::vector<%s>", text)
+		inner := *schema
+		inner.IsArray = false
+		ret, err := ToTypeString(prefix, &inner)
+		if err != nil {
+			return "xxx", fmt.Errorf("ToParamString inner value error: %s", err)
+		}
+		text = fmt.Sprintf("const std::list<%s>&", ret)
 	}
 	return text, nil
 }

--- a/pkg/gen/filters/filtercpp/cpp_type.go
+++ b/pkg/gen/filters/filtercpp/cpp_type.go
@@ -1,3 +1,52 @@
 package filtercpp
 
-var cppType = cppReturn
+import (
+	"fmt"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+func ToTypeString(prefix string, schema *model.Schema) (string, error) {
+	t := schema.Type
+	text := ""
+	switch t {
+	case "void":
+		text = "void"
+	case "string":
+		text = "std::string"
+	case "int":
+		text = "int"
+	case "float":
+		text = "float"
+	case "bool":
+		text = "bool"
+	default:
+		if schema.Module == nil {
+			return "xxx", fmt.Errorf("schema.Module is nil")
+		}
+		e := schema.Module.LookupEnum(t)
+		if e != nil {
+			text = fmt.Sprintf("%s%sEnum", prefix, e.Name)
+		}
+		s := schema.Module.LookupStruct(t)
+		if s != nil {
+			text = fmt.Sprintf("%s%s", prefix, s.Name)
+		}
+		i := schema.Module.LookupInterface(t)
+		if i != nil {
+			text = fmt.Sprintf("%s%s*", prefix, i.Name)
+		}
+	}
+	if schema.IsArray {
+		text = fmt.Sprintf("std::list<%s>", text)
+	}
+	return text, nil
+}
+
+// cast value to TypedNode and deduct the cpp return type
+func cppType(prefix string, node *model.TypedNode) (string, error) {
+	if node == nil {
+		return "xxx", fmt.Errorf("cppType node is nil")
+	}
+	return ToTypeString(prefix, &node.Schema)
+}


### PR DESCRIPTION
Changes made so the template are identical (+/- few whitespaces which I considered are better)

- Switch back to float type from double
- switch back to list type from vector
- add "Enum" postfix for enum class types, generated class contains that postfix and it needs to be added for enum type
- align some "type&" instead of "type &"
Difference between cppType and cppReturn
cppReturn was used with a flag - which I found created either raw type or returned const& for complex types 
now cppReturn is the one that gives back const& for complex type
and cppType retuns just raw type
also cppParam uses this const& version

TESTS ARE NOT ALIGNED