### PR TITLE
adding js filters

### DIFF
--- a/pkg/gen/filters/filterjs/filters.go
+++ b/pkg/gen/filters/filterjs/filters.go
@@ -1,0 +1,16 @@
+package filterjs
+
+import (
+	"text/template"
+)
+
+// PopulateFuncMap fills the given FuncMap with the functions from this package.
+func PopulateFuncMap(fm template.FuncMap) {
+	fm["jsReturn"] = jsReturn
+	fm["jsDefault"] = jsDefault
+	fm["jsParam"] = jsParam
+	fm["jsParams"] = jsParams
+	fm["jsVar"] = jsVar
+	fm["jsVars"] = jsVars
+	fm["jsType"] = jsType
+}

--- a/pkg/gen/filters/filterjs/js_default.go
+++ b/pkg/gen/filters/filterjs/js_default.go
@@ -1,0 +1,63 @@
+package filterjs
+
+import (
+	"fmt"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+// ToDefaultString returns the default value for a type
+func ToDefaultString(schema *model.Schema, prefix string) (string, error) {
+	if schema == nil {
+		return "xxx", fmt.Errorf("ToDefaultString schema is nil")
+	}
+	if schema.Module == nil {
+		return "xxx", fmt.Errorf("ToDefaultString schema module is nil")
+	}
+	var text string
+	if schema.IsArray {
+		text = "[]"
+	} else {
+		switch schema.KindType {
+		case model.TypeString:
+			text = "\"\""
+		case model.TypeInt, model.TypeInt32, model.TypeInt64:
+			text = "0"
+		case model.TypeFloat, model.TypeFloat32, model.TypeFloat64:
+			text = "0.0"
+		case model.TypeBool:
+			text = "false"
+		case model.TypeEnum:
+			e := schema.Module.LookupEnum(schema.Type)
+			if e == nil {
+				return "xxx", fmt.Errorf("ToDefaultString enum %s not found", schema.Type)
+			}
+			text = fmt.Sprintf("%s.%s", e.Name, e.Members[0].Name)
+		case model.TypeStruct:
+			s := schema.Module.LookupStruct(schema.Type)
+			if s == nil {
+				return "xxx", fmt.Errorf("ToDefaultString struct %s not found", schema.Type)
+			}
+			text = fmt.Sprintf("new %s%s()", prefix, s.Name)
+		case model.TypeInterface:
+			i := schema.Module.LookupInterface(schema.Type)
+			if i == nil {
+				return "xxx", fmt.Errorf("ToDefaultString interface %s not found", schema.Type)
+			}
+			text = "null"
+		case model.TypeVoid:
+			text = "void"
+		default:
+			return "xxx", fmt.Errorf("unknown schema kind type: %s", schema.KindType)
+		}
+	}
+	return text, nil
+}
+
+// cppDefault returns the default value for a type
+func jsDefault(prefix string, node *model.TypedNode) (string, error) {
+	if node == nil {
+		return "xxx", fmt.Errorf("jsDefault called with nil node")
+	}
+	return ToDefaultString(&node.Schema, prefix)
+}

--- a/pkg/gen/filters/filterjs/js_default_test.go
+++ b/pkg/gen/filters/filterjs/js_default_test.go
@@ -1,0 +1,82 @@
+package filterjs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// test with all the types
+// properties, operation params, operation return, signal params, struct fields
+func TestDefaultFromIdl(t *testing.T) {
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test1", "propVoid", "void"},
+		{"test", "Test1", "propBool", "false"},
+		{"test", "Test1", "propInt", "0"},
+		{"test", "Test1", "propInt32", "0"},
+		{"test", "Test1", "propInt64", "0"},
+		{"test", "Test1", "propFloat", "0.0"},
+		{"test", "Test1", "propFloat32", "0.0"},
+		{"test", "Test1", "propFloat64", "0.0"},
+		{"test", "Test1", "propString", "\"\""},
+		{"test", "Test1", "propBoolArray", "[]"},
+		{"test", "Test1", "propIntArray", "[]"},
+		{"test", "Test1", "propInt32Array", "[]"},
+		{"test", "Test1", "propInt64Array", "[]"},
+		{"test", "Test1", "propFloatArray", "[]"},
+		{"test", "Test1", "propFloat32Array", "[]"},
+		{"test", "Test1", "propFloat64Array", "[]"},
+		{"test", "Test1", "propStringArray", "[]"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := jsDefault("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestDefaultSymbolsFromIdl(t *testing.T) {
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test2", "propEnum", "Enum1.Default"},
+		{"test", "Test2", "propStruct", "new Struct1()"},
+		{"test", "Test2", "propInterface", "null"},
+		{"test", "Test2", "propEnumArray", "[]"},
+		{"test", "Test2", "propStructArray", "[]"},
+		{"test", "Test2", "propInterfaceArray", "[]"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := jsDefault("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestDefaultWithErrors(t *testing.T) {
+	s, err := jsDefault("", nil)
+	assert.Error(t, err)
+	assert.Equal(t, "xxx", s)
+}

--- a/pkg/gen/filters/filterjs/js_param.go
+++ b/pkg/gen/filters/filterjs/js_param.go
@@ -1,0 +1,55 @@
+package filterjs
+
+import (
+	"fmt"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+func ToParamString(schema *model.Schema, name string, prefix string) (string, error) {
+	if schema == nil {
+		return "xxx", fmt.Errorf("ToParamString schema is nil")
+	}
+	if schema.IsArray {
+		inner := *schema
+		inner.IsArray = false
+		return name, nil
+	}
+	switch schema.KindType {
+	case model.TypeString:
+		return name, nil
+	case model.TypeInt, model.TypeInt32, model.TypeInt64:
+		return name, nil
+	case model.TypeFloat, model.TypeFloat32, model.TypeFloat64:
+		return name, nil
+	case model.TypeBool:
+		return name, nil
+	case model.TypeEnum:
+		e := schema.Module.LookupEnum(schema.Type)
+		if e == nil {
+			return "xxx", fmt.Errorf("ToParamString enum %s not found", schema.Type)
+		}
+		return name, nil
+	case model.TypeStruct:
+		s := schema.Module.LookupStruct(schema.Type)
+		if s == nil {
+			return "xxx", fmt.Errorf("ToParamString struct %s not found", schema.Type)
+		}
+		return name, nil
+	case model.TypeInterface:
+		i := schema.Module.LookupInterface(schema.Type)
+		if i == nil {
+			return "xxx", fmt.Errorf("ToParamString interface %s not found", schema.Type)
+		}
+		return name, nil
+	default:
+		return "xxx", fmt.Errorf("unknown schema kind type: %s", schema.KindType)
+	}
+}
+
+func jsParam(prefix string, node *model.TypedNode) (string, error) {
+	if node == nil {
+		return "xxx", fmt.Errorf("jsParam called with nil node")
+	}
+	return ToParamString(&node.Schema, node.Name, prefix)
+}

--- a/pkg/gen/filters/filterjs/js_param_test.go
+++ b/pkg/gen/filters/filterjs/js_param_test.go
@@ -1,0 +1,72 @@
+package filterjs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParam(t *testing.T) {
+	table := []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test1", "propBool", "propBool"},
+		{"test", "Test1", "propInt32", "propInt32"},
+		{"test", "Test1", "propInt64", "propInt64"},
+		{"test", "Test1", "propFloat", "propFloat"},
+		{"test", "Test1", "propFloat32", "propFloat32"},
+		{"test", "Test1", "propFloat64", "propFloat64"},
+		{"test", "Test1", "propString", "propString"},
+		{"test", "Test1", "propBoolArray", "propBoolArray"},
+		{"test", "Test1", "propIntArray", "propIntArray"},
+		{"test", "Test1", "propInt32Array", "propInt32Array"},
+		{"test", "Test1", "propInt64Array", "propInt64Array"},
+		{"test", "Test1", "propFloatArray", "propFloatArray"},
+		{"test", "Test1", "propFloat32Array", "propFloat32Array"},
+		{"test", "Test1", "propFloat64Array", "propFloat64Array"},
+		{"test", "Test1", "propStringArray", "propStringArray"},
+	}
+	syss := loadTestSystems(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := jsParam("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestParamSymbols(t *testing.T) {
+	table := []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test2", "propEnum", "propEnum"},
+		{"test", "Test2", "propStruct", "propStruct"},
+		{"test", "Test2", "propInterface", "propInterface"},
+		{"test", "Test2", "propEnumArray", "propEnumArray"},
+		{"test", "Test2", "propStructArray", "propStructArray"},
+		{"test", "Test2", "propInterfaceArray", "propInterfaceArray"},
+	}
+	syss := loadTestSystems(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := jsParam("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}

--- a/pkg/gen/filters/filterjs/js_params.go
+++ b/pkg/gen/filters/filterjs/js_params.go
@@ -1,0 +1,19 @@
+package filterjs
+
+import (
+	"strings"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+func jsParams(prefix string, nodes []*model.TypedNode) (string, error) {
+	var params []string
+	for _, n := range nodes {
+		r, err := ToParamString(&n.Schema, n.Name, prefix)
+		if err != nil {
+			return "xxx", err
+		}
+		params = append(params, r)
+	}
+	return strings.Join(params, ", "), nil
+}

--- a/pkg/gen/filters/filterjs/js_params_test.go
+++ b/pkg/gen/filters/filterjs/js_params_test.go
@@ -1,0 +1,102 @@
+package filterjs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParams(t *testing.T) {
+	table := []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test3", "opBool", "param1"},
+		{"test", "Test3", "opInt", "param1"},
+		{"test", "Test3", "opInt32", "param1"},
+		{"test", "Test3", "opInt64", "param1"},
+		{"test", "Test3", "opFloat", "param1"},
+		{"test", "Test3", "opFloat32", "param1"},
+		{"test", "Test3", "opFloat64", "param1"},
+		{"test", "Test3", "opString", "param1"},
+		{"test", "Test3", "opBoolArray", "param1"},
+		{"test", "Test3", "opIntArray", "param1"},
+		{"test", "Test3", "opInt32Array", "param1"},
+		{"test", "Test3", "opInt64Array", "param1"},
+		{"test", "Test3", "opFloatArray", "param1"},
+		{"test", "Test3", "opFloat32Array", "param1"},
+		{"test", "Test3", "opFloat64Array", "param1"},
+		{"test", "Test3", "opStringArray", "param1"},
+	}
+	syss := loadTestSystems(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.pn, func(t *testing.T) {
+				m := sys.LookupOperation(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, m)
+				r, err := jsParams("", m.Params)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestParamsSymbols(t *testing.T) {
+	table := []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test4", "opEnum", "param1"},
+		{"test", "Test4", "opStruct", "param1"},
+		{"test", "Test4", "opInterface", "param1"},
+		{"test", "Test4", "opEnumArray", "param1"},
+		{"test", "Test4", "opStructArray", "param1"},
+		{"test", "Test4", "opInterfaceArray", "param1"},
+	}
+	syss := loadTestSystems(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.pn, func(t *testing.T) {
+				m := sys.LookupOperation(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, m)
+				r, err := jsParams("", m.Params)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestParamsMultiple(t *testing.T) {
+	table := []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test5", "opBoolBool", "param1, param2"},
+		{"test", "Test5", "opIntInt", "param1, param2"},
+		{"test", "Test5", "opFloatFloat", "param1, param2"},
+		{"test", "Test5", "opStringString", "param1, param2"},
+		{"test", "Test5", "opEnumEnum", "param1, param2"},
+		{"test", "Test5", "opStructStruct", "param1, param2"},
+		{"test", "Test5", "opInterfaceInterface", "param1, param2"},
+	}
+	syss := loadTestSystems(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.pn, func(t *testing.T) {
+				m := sys.LookupOperation(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, m)
+				r, err := jsParams("", m.Params)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}

--- a/pkg/gen/filters/filterjs/js_return.go
+++ b/pkg/gen/filters/filterjs/js_return.go
@@ -1,0 +1,55 @@
+package filterjs
+
+import (
+	"fmt"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+func ToReturnString(schema *model.Schema, prefix string) (string, error) {
+	text := ""
+	switch schema.KindType {
+	case model.TypeString:
+		text = ""
+	case model.TypeInt, model.TypeInt32, model.TypeInt64:
+		text = ""
+	case model.TypeFloat, model.TypeFloat32, model.TypeFloat64:
+		text = ""
+	case model.TypeBool:
+		text = ""
+	case model.TypeEnum:
+		e := schema.Module.LookupEnum(schema.Type)
+		if e == nil {
+			return "xxx", fmt.Errorf("ToReturnString enum %s not found", schema.Type)
+		}
+		text = ""
+	case model.TypeStruct:
+		s := schema.Module.LookupStruct(schema.Type)
+		if s == nil {
+			return "xxx", fmt.Errorf("ToReturnString struct %s not found", schema.Type)
+		}
+		text = ""
+	case model.TypeInterface:
+		i := schema.Module.LookupInterface(schema.Type)
+		if i == nil {
+			return "xxx", fmt.Errorf("ToReturnString interface %s not found", schema.Type)
+		}
+		text = ""
+	case model.TypeVoid:
+		text = ""
+	default:
+		return "xxx", fmt.Errorf("unknown schema kind type: %s", schema.KindType)
+	}
+	if schema.IsArray {
+		text = ""
+	}
+	return text, nil
+}
+
+// cast value to TypedNode and deduct the cpp return type
+func jsReturn(prefix string, node *model.TypedNode) (string, error) {
+	if node == nil {
+		return "xxx", fmt.Errorf("jsReturn called with nil node")
+	}
+	return ToReturnString(&node.Schema, prefix)
+}

--- a/pkg/gen/filters/filterjs/js_return_test.go
+++ b/pkg/gen/filters/filterjs/js_return_test.go
@@ -1,0 +1,106 @@
+package filterjs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// test with all the types
+// properties, operation params, operation return, signal params, struct fields
+func TestReturn(t *testing.T) {
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test1", "propVoid", ""},
+		{"test", "Test1", "propBool", ""},
+		{"test", "Test1", "propInt", ""},
+		{"test", "Test1", "propInt32", ""},
+		{"test", "Test1", "propInt64", ""},
+		{"test", "Test1", "propFloat", ""},
+		{"test", "Test1", "propFloat32", ""},
+		{"test", "Test1", "propFloat64", ""},
+		{"test", "Test1", "propString", ""},
+		{"test", "Test1", "propBoolArray", ""},
+		{"test", "Test1", "propIntArray", ""},
+		{"test", "Test1", "propInt32Array", ""},
+		{"test", "Test1", "propInt64Array", ""},
+		{"test", "Test1", "propFloatArray", ""},
+		{"test", "Test1", "propFloat32Array", ""},
+		{"test", "Test1", "propFloat64Array", ""},
+		{"test", "Test1", "propStringArray", ""},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := jsReturn("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestOperationReturn(t *testing.T) {
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test3", "opVoid", ""},
+		{"test", "Test3", "opBool", ""},
+		{"test", "Test3", "opInt", ""},
+		{"test", "Test3", "opFloat", ""},
+		{"test", "Test3", "opString", ""},
+		{"test", "Test3", "opBoolArray", ""},
+		{"test", "Test3", "opIntArray", ""},
+		{"test", "Test3", "opFloatArray", ""},
+		{"test", "Test3", "opStringArray", ""},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				op := sys.LookupOperation(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, op)
+				r, err := jsReturn("", op.Return)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+func TestReturnSymbols(t *testing.T) {
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test2", "propEnum", ""},
+		{"test", "Test2", "propStruct", ""},
+		{"test", "Test2", "propInterface", ""},
+		{"test", "Test2", "propEnumArray", ""},
+		{"test", "Test2", "propStructArray", ""},
+		{"test", "Test2", "propInterfaceArray", ""},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := jsReturn("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}

--- a/pkg/gen/filters/filterjs/js_type.go
+++ b/pkg/gen/filters/filterjs/js_type.go
@@ -1,0 +1,3 @@
+package filterjs
+
+var jsType = jsReturn

--- a/pkg/gen/filters/filterjs/js_var.go
+++ b/pkg/gen/filters/filterjs/js_var.go
@@ -1,0 +1,19 @@
+package filterjs
+
+import (
+	"fmt"
+
+	"github.com/apigear-io/cli/pkg/model"
+	"github.com/ettle/strcase"
+)
+
+func ToVarString(node *model.TypedNode) (string, error) {
+	if node == nil {
+		return "xxx", fmt.Errorf("ToVarString node is nil")
+	}
+	return strcase.ToCamel(node.Name), nil
+}
+
+func jsVar(node *model.TypedNode) (string, error) {
+	return ToVarString(node)
+}

--- a/pkg/gen/filters/filterjs/js_var_test.go
+++ b/pkg/gen/filters/filterjs/js_var_test.go
@@ -1,0 +1,76 @@
+package filterjs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// test with all the types
+// properties, operation params, operation return, signal params, struct fields
+func TestVar(t *testing.T) {
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+
+		{"test", "Test1", "propBool", "propBool"},
+		{"test", "Test1", "propInt", "propInt"},
+		{"test", "Test1", "propInt32", "propInt32"},
+		{"test", "Test1", "propInt64", "propInt64"},
+		{"test", "Test1", "propFloat", "propFloat"},
+		{"test", "Test1", "propFloat32", "propFloat32"},
+		{"test", "Test1", "propFloat64", "propFloat64"},
+		{"test", "Test1", "propString", "propString"},
+		{"test", "Test1", "propBoolArray", "propBoolArray"},
+		{"test", "Test1", "propIntArray", "propIntArray"},
+		{"test", "Test1", "propInt32Array", "propInt32Array"},
+		{"test", "Test1", "propInt64Array", "propInt64Array"},
+		{"test", "Test1", "propFloatArray", "propFloatArray"},
+		{"test", "Test1", "propFloat32Array", "propFloat32Array"},
+		{"test", "Test1", "propFloat64Array", "propFloat64Array"},
+		{"test", "Test1", "propStringArray", "propStringArray"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := jsVar(prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestVarSymbols(t *testing.T) {
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test2", "propEnum", "propEnum"},
+		{"test", "Test2", "propStruct", "propStruct"},
+		{"test", "Test2", "propInterface", "propInterface"},
+		{"test", "Test2", "propEnumArray", "propEnumArray"},
+		{"test", "Test2", "propStructArray", "propStructArray"},
+		{"test", "Test2", "propInterfaceArray", "propInterfaceArray"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := jsVar(prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}

--- a/pkg/gen/filters/filterjs/js_vars.go
+++ b/pkg/gen/filters/filterjs/js_vars.go
@@ -1,0 +1,23 @@
+package filterjs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+func jsVars(nodes []*model.TypedNode) (string, error) {
+	if nodes == nil {
+		return "xxx", fmt.Errorf("jsVars called with nil nodes")
+	}
+	names := make([]string, len(nodes))
+	for idx, p := range nodes {
+		name, err := ToVarString(p)
+		if err != nil {
+			return "xxx", err
+		}
+		names[idx] = name
+	}
+	return strings.Join(names, ", "), nil
+}

--- a/pkg/gen/filters/filterjs/js_vars_test.go
+++ b/pkg/gen/filters/filterjs/js_vars_test.go
@@ -1,0 +1,103 @@
+package filterjs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVars(t *testing.T) {
+	table := []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test3", "opBool", "param1"},
+		{"test", "Test3", "opInt", "param1"},
+		{"test", "Test3", "opInt32", "param1"},
+		{"test", "Test3", "opInt64", "param1"},
+		{"test", "Test3", "opFloat", "param1"},
+		{"test", "Test3", "opFloat32", "param1"},
+		{"test", "Test3", "opFloat64", "param1"},
+		{"test", "Test3", "opString", "param1"},
+		{"test", "Test3", "opBoolArray", "param1"},
+		{"test", "Test3", "opIntArray", "param1"},
+		{"test", "Test3", "opInt32Array", "param1"},
+		{"test", "Test3", "opInt64Array", "param1"},
+		{"test", "Test3", "opFloatArray", "param1"},
+		{"test", "Test3", "opFloat32Array", "param1"},
+		{"test", "Test3", "opFloat64Array", "param1"},
+		{"test", "Test3", "opStringArray", "param1"},
+	}
+	syss := loadTestSystems(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.pn, func(t *testing.T) {
+				meth := sys.LookupOperation(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, meth)
+				r, err := jsVars(meth.Params)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestVarsSymbols(t *testing.T) {
+	table := []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+
+		{"test", "Test4", "opEnum", "param1"},
+		{"test", "Test4", "opStruct", "param1"},
+		{"test", "Test4", "opInterface", "param1"},
+		{"test", "Test4", "opEnumArray", "param1"},
+		{"test", "Test4", "opStructArray", "param1"},
+		{"test", "Test4", "opInterfaceArray", "param1"},
+	}
+	syss := loadTestSystems(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupOperation(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := jsVars(prop.Params)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestVarsMultiple(t *testing.T) {
+	table := []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test5", "opBoolBool", "param1, param2"},
+		{"test", "Test5", "opIntInt", "param1, param2"},
+		{"test", "Test5", "opFloatFloat", "param1, param2"},
+		{"test", "Test5", "opStringString", "param1, param2"},
+		{"test", "Test5", "opEnumEnum", "param1, param2"},
+		{"test", "Test5", "opStructStruct", "param1, param2"},
+		{"test", "Test5", "opInterfaceInterface", "param1, param2"},
+	}
+	syss := loadTestSystems(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupOperation(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := jsVars(prop.Params)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}

--- a/pkg/gen/filters/filterjs/loader.go
+++ b/pkg/gen/filters/filterjs/loader.go
@@ -1,0 +1,27 @@
+package filterjs
+
+import (
+	"testing"
+
+	"github.com/apigear-io/cli/pkg/idl"
+	"github.com/apigear-io/cli/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func loadTestSystems(t *testing.T) []*model.System {
+	t.Helper()
+	sys1 := model.NewSystem("sys1")
+	p := idl.NewParser(sys1)
+	err := p.ParseFile("../testdata/test.idl")
+	assert.NoError(t, err)
+	err = sys1.ResolveAll()
+	assert.NoError(t, err)
+
+	sys2 := model.NewSystem("sys2")
+	dp := model.NewDataParser(sys2)
+	err = dp.ParseFile("../testdata/test.module.yaml")
+	assert.NoError(t, err)
+	err = sys2.ResolveAll()
+	assert.NoError(t, err)
+	return []*model.System{sys1}
+}

--- a/pkg/gen/filters/funcmap.go
+++ b/pkg/gen/filters/funcmap.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/apigear-io/cli/pkg/gen/filters/filtercpp"
 	"github.com/apigear-io/cli/pkg/gen/filters/filtergo"
+	"github.com/apigear-io/cli/pkg/gen/filters/filterjs"
 	"github.com/apigear-io/cli/pkg/gen/filters/filterpy"
 	"github.com/apigear-io/cli/pkg/gen/filters/filterqt"
 	"github.com/apigear-io/cli/pkg/gen/filters/filterts"
@@ -55,6 +56,7 @@ func PopulateFuncMap() template.FuncMap {
 	filterpy.PopulateFuncMap(fm)
 	filterue.PopulateFuncMap(fm)
 	filterqt.PopulateFuncMap(fm)
+	filterjs.PopulateFuncMap(fm)
 
 	return fm
 }


### PR DESCRIPTION
JS filters are required for pur JS APIs or mixed JS/TS APIs where the API types are described in the `.d.ts` files. The advantage of a JS/TS mix is that there is no need for typescript in the toolchain. Types are inferred from a typescript compiler if present and if not, the IDEs will infer the types for coding. 

The idea is when we generate code inside an app we can not assume the user uses TS, it might be just a JS app. So to avoid depending on the TS toolchain a JS API with .d.ts files will work in both environments.

Missing

- [x] Documentation
- [x] Remove unused type switches in filters
- [x] Add a proof-of-concept JS template with d.ts support