### PR TITLE
fix(python): use proper struct default value

### DIFF
--- a/pkg/gen/filters/filterpy/py_default.go
+++ b/pkg/gen/filters/filterpy/py_default.go
@@ -41,7 +41,8 @@ func ToDefaultString(schema *model.Schema, prefix string) (string, error) {
 			if s == nil {
 				return "xxx", fmt.Errorf("ToDefaultString struct %s not found", schema.Type)
 			}
-			text = "{}"
+			ident := common.CamelTitleCase(s.Name)
+			text = fmt.Sprintf("%s%s()", prefix, ident)
 		case model.TypeInterface:
 			i := schema.Module.LookupInterface(schema.Type)
 			if i == nil {

--- a/pkg/gen/filters/filterpy/py_default_test.go
+++ b/pkg/gen/filters/filterpy/py_default_test.go
@@ -56,7 +56,7 @@ func TestDefaultSymbolsFromIdl(t *testing.T) {
 		rt string
 	}{
 		{"test", "Test2", "propEnum", "Enum1.DEFAULT"},
-		{"test", "Test2", "propStruct", "{}"},
+		{"test", "Test2", "propStruct", "Struct1()"},
 		{"test", "Test2", "propInterface", "None"},
 		{"test", "Test2", "propEnumArray", "[]"},
 		{"test", "Test2", "propStructArray", "[]"},


### PR DESCRIPTION
The old {} default value caused problems in the python template when it was looking the specific type having a .dict() field on default values.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed