### PR TITLE
Fix Qt vars name filter

### DIFF
--- a/pkg/gen/filters/filterqt/qt_params_test.go
+++ b/pkg/gen/filters/filterqt/qt_params_test.go
@@ -29,6 +29,9 @@ func TestParams(t *testing.T) {
 		{"test", "Test3", "opFloat32Array", "const QList<float>& param1"},
 		{"test", "Test3", "opFloat64Array", "const QList<double>& param1"},
 		{"test", "Test3", "opStringArray", "const QList<QString>& param1"},
+		{"test", "Test3", "op_Bool", "bool param_Bool"},
+		{"test", "Test3", "op_bool", "bool param_bool"},
+		{"test", "Test3", "op_1", "bool param_1"},
 	}
 	syss := loadTestSystems(t)
 	for _, sys := range syss {

--- a/pkg/gen/filters/filterqt/qt_var.go
+++ b/pkg/gen/filters/filterqt/qt_var.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 
 	"github.com/apigear-io/cli/pkg/model"
-	"github.com/ettle/strcase"
 )
 
 func ToVarString(node *model.TypedNode) (string, error) {
 	if node == nil {
 		return "xxx", fmt.Errorf("ToVarString node is nil")
 	}
-	return strcase.ToCamel(node.Name), nil
+	return node.Name, nil
 }
 
 func qtVar(node *model.TypedNode) (string, error) {

--- a/pkg/gen/filters/filterqt/qt_vars_test.go
+++ b/pkg/gen/filters/filterqt/qt_vars_test.go
@@ -29,6 +29,9 @@ func TestVars(t *testing.T) {
 		{"test", "Test3", "opFloat32Array", "param1"},
 		{"test", "Test3", "opFloat64Array", "param1"},
 		{"test", "Test3", "opStringArray", "param1"},
+		{"test", "Test3", "op_Bool", "param_Bool"},
+		{"test", "Test3", "op_bool", "param_bool"},
+		{"test", "Test3", "op_1", "param_1"},
 	}
 	syss := loadTestSystems(t)
 	for _, sys := range syss {

--- a/pkg/gen/filters/testdata/test.idl
+++ b/pkg/gen/filters/testdata/test.idl
@@ -47,6 +47,9 @@ interface Test3 {
     opFloat32Array(param1: float32[]): float32[]
     opFloat64Array(param1: float64[]): float64[]
     opStringArray(param1: string[]): string[]
+    op_Bool(param_Bool: bool): bool
+    op_bool(param_bool: bool): bool
+    op_1(param_1: bool): bool
 }
 
 interface Test4 {

--- a/pkg/gen/filters/testdata/test.module.yaml
+++ b/pkg/gen/filters/testdata/test.module.yaml
@@ -141,6 +141,18 @@ interfaces:
         return:
           type: string
           array: true
+      - name: op_Bool
+        params:
+          - name: param_Bool
+            type: bool
+      - name: op_bool
+        params:
+          - name: param_bool
+            type: bool
+      - name: op_1
+        params:
+          - name: param_1
+            type: bool
   - name: Test4
     operations:
       - name: opEnum


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->
The Qt vars filter was not in sync with the Qt params filter. In some cases the filters generated different names for the same variables which broke the compilation.
With this change we remove the camel casing in the Qt vars filter and add tests for this case.
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->