### PR TITLE
ensure user editable content is not overridden

### DIFF
--- a/pkg/gen/generator_test.go
+++ b/pkg/gen/generator_test.go
@@ -66,6 +66,8 @@ func TestHelloRules(t *testing.T) {
 	r := readRules(t, "testdata/test.rules.yaml")
 	err := g.ProcessRules(r)
 	assert.NoError(t, err)
+	length := len(g.Stats.FilesTouched)
+	assert.Equal(t, length, 1)
 	assert.Contains(t, g.Stats.FilesTouched[0], "system.txt")
 }
 

--- a/pkg/gen/out.go
+++ b/pkg/gen/out.go
@@ -17,6 +17,7 @@ type FileOutput struct {
 }
 
 func (f *FileOutput) Write(input []byte, target string, force bool) error {
+
 	// write document to file system
 	dir := filepath.Dir(target)
 	err := os.MkdirAll(dir, 0755)

--- a/pkg/gen/testdata/test.rules.yaml
+++ b/pkg/gen/testdata/test.rules.yaml
@@ -3,7 +3,7 @@ features:
     scopes:
       - match: system
         documents:
-          - { source: "system.name.tpl", target: "system.txt" }
+          - { source: "system.name.tpl", target: "system.txt", force: true }
       - match: module
         documents:
           - { source: "module.name.tpl", target: "module.txt" }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -30,7 +30,7 @@ func init() {
 		level = zerolog.TraceLevel
 	}
 	logFile := helper.Join(cfg.ConfigDir(), "apigear.log")
-	console := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05"}
+	console := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05", FieldsExclude: []string{"id"}}
 	multi := zerolog.MultiLevelWriter(
 		console,
 		NewEventLogWriter(),


### PR DESCRIPTION
The document force from rules and the user force from command line, needed to have some logic change.

If the document shall not be forced overwritten (default), skip file
if the document can be overwritten and same content, skip
if document can be overwritten and force is enabled, skip comparison and write