### PR TITLE
Rules cli version

### DIFF
--- a/cmd/apigear/main.go
+++ b/cmd/apigear/main.go
@@ -17,7 +17,12 @@ var (
 
 // main entry point for apigear cli tool
 func main() {
-	cfg.SetBuildInfo(version, commit, date)
+	cfg.SetBuildInfo("cli", cfg.BuildInfo{
+		Version: version,
+		Commit:  commit,
+		Date:    date,
+	})
+
 	log.Debug().Msgf("version: %s-%s-%s", version, commit, date)
 	err := cmd.Run()
 	if err != nil {

--- a/data/project/apigear/demo.solution.yaml
+++ b/data/project/apigear/demo.solution.yaml
@@ -1,6 +1,6 @@
 schema: apigear.solution/1.0
 layers:
-  - template: apigear-io/template-qtcpp
+  - template: ./template
     inputs:
       - sample.module.yaml
     output: ../out

--- a/data/project/apigear/template/rules.yaml
+++ b/data/project/apigear/template/rules.yaml
@@ -1,5 +1,7 @@
 schema: apigear.rules/1.0
 name: template rules
+engines:
+  cli: ">=v0.35"
 features:
   - name: core
     scopes:

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -17,7 +17,7 @@ func NewUpdateCommand() *cobra.Command {
 		Long:  `check and update the program to the latest version`,
 		Run: func(cmd *cobra.Command, args []string) {
 			repo := "apigear-io/cli"
-			version := cfg.BuildVersion()
+			version := cfg.GetBuildInfo("cli").Version
 			ctx := context.Background()
 			u, err := up.NewUpdater(repo, version)
 			if err != nil {

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -13,10 +13,8 @@ func NewVersionCommand() *cobra.Command {
 		Short: "display version information",
 		Long:  `display version, commit and build-date information`,
 		Run: func(cmd *cobra.Command, args []string) {
-			version := cfg.BuildVersion()
-			commit := cfg.BuildCommit()
-			date := cfg.BuildDate()
-			fmt.Printf("%s-%s-%s\n", version, commit, date)
+			bi := cfg.GetBuildInfo("cli")
+			fmt.Printf("cli: %s-%s-%s\n", bi.Version, bi.Commit, bi.Date)
 		},
 	}
 	return cmd

--- a/pkg/spec/schema/apigear.rules.schema.json
+++ b/pkg/spec/schema/apigear.rules.schema.json
@@ -93,8 +93,19 @@
       "type": "object"
     }
   },
-  "description": "Rules engine to drive the object api generator\nA typical setup looks like this:\n```\nschema: apigear.rules/1.0\nname: simple cpp template\nfeatures:\n  - name: api\n    path: {{dot .Module.Name}}/\n    scopes:\n      - match: module\n        documents:\n          - source: api.h\n            target: api.h\n\n  - name: core\n    requires: [api]\n    path: {{dot .Module.Name}}/\n    scopes:\n      - match: module\n        documents:\n          - source: core.h\n          - target: core.h\n          - source: core.cpp\n            target: core.cpp\n  - name: init\n    requires: [core]\n    path: {{dot .Module.Name}}/\n    scopes:\n      - name: module\n        documents:\n          - source: Makefile\n          - source: service.h\n            target: {{snake .Interface.Name}}.h\n          - source: service.cpp\n            target: {{snake .Interface.Name}}.cpp\n```\n",
+  "description": "Rules engine to drive the object api generator\nA typical setup looks like this:\n```\nschema: apigear.rules/1.0\nname: simple cpp template\nengines:\n  cli: \"\u003e= v0.1.0 \u003c v1.0.0\"\nfeatures:\n  - name: api\n    path: {{dot .Module.Name}}/\n    scopes:\n      - match: module\n        documents:\n          - source: api.h\n            target: api.h\n\n  - name: core\n    requires: [api]\n    path: {{dot .Module.Name}}/\n    scopes:\n      - match: module\n        documents:\n          - source: core.h\n          - target: core.h\n          - source: core.cpp\n            target: core.cpp\n  - name: init\n    requires: [core]\n    path: {{dot .Module.Name}}/\n    scopes:\n      - name: module\n        documents:\n          - source: Makefile\n          - source: service.h\n            target: {{snake .Interface.Name}}.h\n          - source: service.cpp\n            target: {{snake .Interface.Name}}.cpp\n```\n",
   "properties": {
+    "engines": {
+      "additionalProperties": false,
+      "description": "Engines defines a list engine versions which are supported by this rules engine.",
+      "properties": {
+        "cli": {
+          "description": "SemVer version constraint for the cli engine (e.g. \"\u003e= v0.1.0 \u003c v1.0.0\")",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "features": {
       "description": "Features define a set of factory sections which can be enabled/disabled on the command line. typically it should contain api, core and init.",
       "items": {

--- a/pkg/spec/schema/apigear.rules.schema.yaml
+++ b/pkg/spec/schema/apigear.rules.schema.yaml
@@ -8,6 +8,8 @@ description: |
   ```
   schema: apigear.rules/1.0
   name: simple cpp template
+  engines:
+    cli: ">= v0.1.0 < v1.0.0"
   features:
     - name: api
       path: {{dot .Module.Name}}/
@@ -55,6 +57,14 @@ properties:
     description: "The version of the rules document. Should be a major and minor and an optional patch version, separated by a dot (e.g. 0.1 or 0.1.0)."
     pattern: "^[0-9]+[.][0-9]+([.][0-9]+)*$"
     default: "0.1.0"
+  engines:
+    type: object
+    description: Engines defines a list engine versions which are supported by this rules engine.
+    additionalProperties: false
+    properties:
+      cli:
+        type: string
+        description: SemVer version constraint for the cli engine (e.g. ">= v0.1.0 < v1.0.0")
   features:
     description: Features define a set of factory sections which can be enabled/disabled on the command line. typically it should contain api, core and init.
     type: array


### PR DESCRIPTION
- allows to define cli version constraints, e.g.

```yaml
// rules.yaml
engines:
  cli: >= v0.3.4
```

A warning will be logged, when cli version check fails.