### PR TITLE
for reserved keywords add `_` suffix

### DIFF
--- a/pkg/gen/filters/common/cases.go
+++ b/pkg/gen/filters/common/cases.go
@@ -6,102 +6,153 @@ import (
 	"github.com/ettle/strcase"
 )
 
+func Preserve_(s string, handler func(string) string) string {
+	if strings.HasSuffix(s, "_") {
+		// remove trailing underscore and add it back
+		s = strings.TrimSuffix(s, "_")
+		s = handler(s)
+		s = s + "_"
+		return s
+	}
+	return handler(s)
+}
+
 // SnakeCaseLower returns a string representation of the value in snake_case.
 func SnakeCaseLower(s string) string {
-	return strcase.ToCase(s, strcase.LowerCase, '_')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.LowerCase, '_')
+	})
 }
 
 // SnakeTitleCase returns a string representation of the value in snake_case.
 func SnakeTitleCase(s string) string {
-	return strcase.ToCase(s, strcase.TitleCase, '_')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.TitleCase, '_')
+	})
 }
 
 // First returns the first character of the value.
 func SnakeUpperCase(s string) string {
-	return strcase.ToCase(s, strcase.UpperCase, '_')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.UpperCase, '_')
+	})
 }
 
 // CamelCase returns a string representation of the value in CamelCase.
 func CamelLowerCase(s string) string {
-	return strcase.ToCase(s, strcase.CamelCase, '\x00')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.CamelCase, '\x00')
+	})
 }
 
 // CamelTitleCase returns a string representation of the value in CamelTitleCase.
 func CamelTitleCase(s string) string {
-	return strcase.ToCase(s, strcase.TitleCase, '\x00')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.TitleCase, '\x00')
+	})
 }
 
 // CamelUpperCase returns a string representation of the value in CamelCase.
 func CamelUpperCase(s string) string {
-	return strcase.ToCase(s, strcase.UpperCase, '\x00')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.UpperCase, '\x00')
+	})
 }
 
 // DotLowerCase returns a string representation of the value in dot.case
 func DotLowerCase(s string) string {
-	return strcase.ToCase(s, strcase.LowerCase, '.')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.LowerCase, '.')
+	})
 }
 
 // DotTitleCase returns a string representation of the value in dot.case
 func DotTitleCase(s string) string {
-	return strcase.ToCase(s, strcase.TitleCase, '.')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.TitleCase, '.')
+	})
 }
 
 // DotUpperCase returns a string representation of the value in DOT.CASE
 func DotUpperCase(s string) string {
-	return strcase.ToCase(s, strcase.UpperCase, '.')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.UpperCase, '.')
+	})
 }
 
 // KebabLowerCase returns a string representation of the value in kebap-case.
 func KebabLowerCase(s string) string {
-	return strcase.ToCase(s, strcase.LowerCase, '-')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.LowerCase, '-')
+	})
 }
 
 // KebabTitleCase returns a string representation of the value in kebab-case.
 func KebabTitleCase(s string) string {
-	return strcase.ToCase(s, strcase.TitleCase, '-')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.TitleCase, '-')
+	})
 }
 
 // KebapCaseUpper returns a string representation of the value in KEBAP-CASE.
 func KebabUpperCase(s string) string {
-	return strcase.ToCase(s, strcase.UpperCase, '-')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.UpperCase, '-')
+	})
 }
 
 // PathLowerCase returns a string representation of the value in path/case.
 func PathLowerCase(s string) string {
-	return strcase.ToCase(s, strcase.LowerCase, '/')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.LowerCase, '/')
+	})
 }
 
 // PathTitleCase returns a string representation of the value in path/case.
 func PathTitleCase(s string) string {
-	return strcase.ToCase(s, strcase.TitleCase, '/')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.TitleCase, '/')
+	})
 }
 
 // PathUpperCase returns a string representation of the value in PATH/CASE.
 func PathUpperCase(s string) string {
-	return strcase.ToCase(s, strcase.UpperCase, '/')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.UpperCase, '/')
+	})
 }
 
 // LowerCase returns a string representation of the value in lowercase.
 func LowerCase(s string) string {
-	return strings.ToLower(s)
+	return Preserve_(s, func(s string) string {
+		return strings.ToLower(s)
+	})
 }
 
 // UpperCase returns a string representation of the value in UPPER CASE.
 func UpperCase(s string) string {
-	return strings.ToUpper(s)
+	return Preserve_(s, func(s string) string {
+		return strings.ToUpper(s)
+	})
 }
 
 // SpaceTitleCase returns a string representation of the value in Space Title Case.
 func SpaceTitleCase(s string) string {
-	return strcase.ToCase(s, strcase.TitleCase, ' ')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.TitleCase, ' ')
+	})
 }
 
 // SpaceUpperCase returns a string representation of the value in SPACE UPPER CASE.
 func SpaceUpperCase(s string) string {
-	return strcase.ToCase(s, strcase.UpperCase, ' ')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.UpperCase, ' ')
+	})
 }
 
 // SpaceLowerCase returns a string representation of the value in space lower case.
 func SpaceLowerCase(s string) string {
-	return strcase.ToCase(s, strcase.LowerCase, ' ')
+	return Preserve_(s, func(s string) string {
+		return strcase.ToCase(s, strcase.LowerCase, ' ')
+	})
 }

--- a/pkg/gen/filters/common/cases_test.go
+++ b/pkg/gen/filters/common/cases_test.go
@@ -1,6 +1,10 @@
 package common
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestSnakeCase(t *testing.T) {
 	t.Parallel()
@@ -16,22 +20,17 @@ func TestSnakeCase(t *testing.T) {
 		{"foo_bar", "foo_bar", "Foo_Bar", "FOO_BAR"},
 		{"foo.bar", "foo_bar", "Foo_Bar", "FOO_BAR"},
 		{"foo1bar", "foo1bar", "Foo1bar", "FOO1BAR"},
+		{"fooBar_", "foo_bar_", "Foo_Bar_", "FOO_BAR_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.lower, func(t *testing.T) {
-			if got := SnakeCaseLower(tt.in); got != tt.lower {
-				t.Errorf("SnakeCaseLower(%q) = %q, want %q", tt.in, got, tt.lower)
-			}
+			assert.Equal(t, tt.lower, SnakeCaseLower(tt.in))
 		})
 		t.Run(tt.title, func(t *testing.T) {
-			if got := SnakeTitleCase(tt.in); got != tt.title {
-				t.Errorf("SnakeTitleCase(%q) = %q, want %q", tt.in, got, tt.title)
-			}
+			assert.Equal(t, tt.title, SnakeTitleCase(tt.in))
 		})
 		t.Run(tt.upper, func(t *testing.T) {
-			if got := SnakeUpperCase(tt.in); got != tt.upper {
-				t.Errorf("SnakeUpperCase(%q) = %q, want %q", tt.in, got, tt.upper)
-			}
+			assert.Equal(t, tt.upper, SnakeUpperCase(tt.in))
 		})
 	}
 }
@@ -50,22 +49,17 @@ func TestCamelCase(t *testing.T) {
 		{"foo_bar", "fooBar", "FooBar", "FOOBAR"},
 		{"foo.bar", "fooBar", "FooBar", "FOOBAR"},
 		{"foo1bar", "foo1bar", "Foo1bar", "FOO1BAR"},
+		{"fooBar_", "fooBar_", "FooBar_", "FOOBAR_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.lower, func(t *testing.T) {
-			if got := CamelLowerCase(tt.in); got != tt.lower {
-				t.Errorf("CamelLowerCase(%q) = %q, want %q", tt.in, got, tt.lower)
-			}
+			assert.Equal(t, tt.lower, CamelLowerCase(tt.in))
 		})
 		t.Run(tt.title, func(t *testing.T) {
-			if got := CamelTitleCase(tt.in); got != tt.title {
-				t.Errorf("CamelTitleCase(%q) = %q, want %q", tt.in, got, tt.title)
-			}
+			assert.Equal(t, tt.title, CamelTitleCase(tt.in))
 		})
 		t.Run(tt.upper, func(t *testing.T) {
-			if got := CamelUpperCase(tt.in); got != tt.upper {
-				t.Errorf("CamelUpperCase(%q) = %q, want %q", tt.in, got, tt.upper)
-			}
+			assert.Equal(t, tt.upper, CamelUpperCase(tt.in))
 		})
 	}
 }
@@ -84,22 +78,17 @@ func TestDotCase(t *testing.T) {
 		{"foo_bar", "foo.bar", "Foo.Bar", "FOO.BAR"},
 		{"foo.bar", "foo.bar", "Foo.Bar", "FOO.BAR"},
 		{"foo1bar", "foo1bar", "Foo1bar", "FOO1BAR"},
+		{"fooBar_", "foo.bar_", "Foo.Bar_", "FOO.BAR_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.lower, func(t *testing.T) {
-			if got := DotLowerCase(tt.in); got != tt.lower {
-				t.Errorf("DotLowerCase(%q) = %q, want %q", tt.in, got, tt.lower)
-			}
+			assert.Equal(t, tt.lower, DotLowerCase(tt.in))
 		})
 		t.Run(tt.title, func(t *testing.T) {
-			if got := DotTitleCase(tt.in); got != tt.title {
-				t.Errorf("DotTitleCase(%q) = %q, want %q", tt.in, got, tt.title)
-			}
+			assert.Equal(t, tt.title, DotTitleCase(tt.in))
 		})
 		t.Run(tt.upper, func(t *testing.T) {
-			if got := DotUpperCase(tt.in); got != tt.upper {
-				t.Errorf("DotUpperCase(%q) = %q, want %q", tt.in, got, tt.upper)
-			}
+			assert.Equal(t, tt.upper, DotUpperCase(tt.in))
 		})
 	}
 }
@@ -118,22 +107,17 @@ func TestKebabCase(t *testing.T) {
 		{"foo_bar", "foo-bar", "Foo-Bar", "FOO-BAR"},
 		{"foo.bar", "foo-bar", "Foo-Bar", "FOO-BAR"},
 		{"foo1bar", "foo1bar", "Foo1bar", "FOO1BAR"},
+		{"fooBar_", "foo-bar_", "Foo-Bar_", "FOO-BAR_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.lower, func(t *testing.T) {
-			if got := KebabLowerCase(tt.in); got != tt.lower {
-				t.Errorf("KebabLowerCase(%q) = %q, want %q", tt.in, got, tt.lower)
-			}
+			assert.Equal(t, tt.lower, KebabLowerCase(tt.in))
 		})
 		t.Run(tt.title, func(t *testing.T) {
-			if got := KebabTitleCase(tt.in); got != tt.title {
-				t.Errorf("KebabTitleCase(%q) = %q, want %q", tt.in, got, tt.title)
-			}
+			assert.Equal(t, tt.title, KebabTitleCase(tt.in))
 		})
 		t.Run(tt.upper, func(t *testing.T) {
-			if got := KebabUpperCase(tt.in); got != tt.upper {
-				t.Errorf("KebabUpperCase(%q) = %q, want %q", tt.in, got, tt.upper)
-			}
+			assert.Equal(t, tt.upper, KebabUpperCase(tt.in))
 		})
 	}
 }
@@ -152,22 +136,17 @@ func TestPathCase(t *testing.T) {
 		{"foo_bar", "foo/bar", "Foo/Bar", "FOO/BAR"},
 		{"foo.bar", "foo/bar", "Foo/Bar", "FOO/BAR"},
 		{"foo1bar", "foo1bar", "Foo1bar", "FOO1BAR"},
+		{"fooBar_", "foo/bar_", "Foo/Bar_", "FOO/BAR_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.lower, func(t *testing.T) {
-			if got := PathLowerCase(tt.in); got != tt.lower {
-				t.Errorf("PathLowerCase(%q) = %q, want %q", tt.in, got, tt.lower)
-			}
+			assert.Equal(t, tt.lower, PathLowerCase(tt.in))
 		})
 		t.Run(tt.title, func(t *testing.T) {
-			if got := PathTitleCase(tt.in); got != tt.title {
-				t.Errorf("PathTitleCase(%q) = %q, want %q", tt.in, got, tt.title)
-			}
+			assert.Equal(t, tt.title, PathTitleCase(tt.in))
 		})
 		t.Run(tt.upper, func(t *testing.T) {
-			if got := PathUpperCase(tt.in); got != tt.upper {
-				t.Errorf("PathUpperCase(%q) = %q, want %q", tt.in, got, tt.upper)
-			}
+			assert.Equal(t, tt.upper, PathUpperCase(tt.in))
 		})
 	}
 }
@@ -184,12 +163,11 @@ func TestUpperCase(t *testing.T) {
 		{"foo_bar", "FOO_BAR"},
 		{"foo.bar", "FOO.BAR"},
 		{"foo1bar", "FOO1BAR"},
+		{"fooBar_", "FOOBAR_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.up, func(t *testing.T) {
-			if got := UpperCase(tt.in); got != tt.up {
-				t.Errorf("Upper(%q) = %q, want %q", tt.in, got, tt.up)
-			}
+			assert.Equal(t, tt.up, UpperCase(tt.in))
 		})
 	}
 }
@@ -206,12 +184,11 @@ func TestLowerCase(t *testing.T) {
 		{"foo_bar", "foo_bar"},
 		{"foo.bar", "foo.bar"},
 		{"foo1bar", "foo1bar"},
+		{"fooBar_", "foobar_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.lw, func(t *testing.T) {
-			if got := LowerCase(tt.in); got != tt.lw {
-				t.Errorf("Lower(%q) = %q, want %q", tt.in, got, tt.lw)
-			}
+			assert.Equal(t, tt.lw, LowerCase(tt.in))
 		})
 	}
 }

--- a/pkg/gen/filters/common/strings.go
+++ b/pkg/gen/filters/common/strings.go
@@ -61,7 +61,7 @@ func TrimSuffix(s, postfix string) string {
 }
 
 func Replace(s, old, new string) string {
-	return strings.Replace(s, old, new, -1)
+	return strings.ReplaceAll(s, old, new)
 }
 
 func Split(s, sep string) []string {

--- a/pkg/gen/filters/common/strings_test.go
+++ b/pkg/gen/filters/common/strings_test.go
@@ -1,6 +1,10 @@
 package common
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestUpperFirst(t *testing.T) {
 	t.Parallel()
@@ -14,12 +18,11 @@ func TestUpperFirst(t *testing.T) {
 		{"foo_bar", "Foo_bar"},
 		{"foo.bar", "Foo.bar"},
 		{"foo1bar", "Foo1bar"},
+		{"fooBar_", "FooBar_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.up, func(t *testing.T) {
-			if got := UpperFirst(tt.in); got != tt.up {
-				t.Errorf("UpperFirst(%q) = %q, want %q", tt.in, got, tt.up)
-			}
+			assert.Equal(t, tt.up, UpperFirst(tt.in))
 		})
 	}
 }
@@ -36,12 +39,11 @@ func TestLowerFirst(t *testing.T) {
 		{"foo_bar", "foo_bar"},
 		{"foo.bar", "foo.bar"},
 		{"foo1bar", "foo1bar"},
+		{"fooBar_", "fooBar_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.lw, func(t *testing.T) {
-			if got := LowerFirst(tt.in); got != tt.lw {
-				t.Errorf("LowerFirst(%q) = %q, want %q", tt.in, got, tt.lw)
-			}
+			assert.Equal(t, tt.lw, LowerFirst(tt.in))
 		})
 	}
 }
@@ -58,12 +60,11 @@ func TestFirstChar(t *testing.T) {
 		{"foo_bar", "f"},
 		{"Foo.Bar", "F"},
 		{"Foo1Bar", "F"},
+		{"FooBar_", "F"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.ch, func(t *testing.T) {
-			if got := FirstChar(tt.in); got != tt.ch {
-				t.Errorf("FirstChar(%q) = %q, want %q", tt.in, got, tt.ch)
-			}
+			assert.Equal(t, tt.ch, FirstChar(tt.in))
 		})
 	}
 }
@@ -81,17 +82,14 @@ func TestFirstCharUpperAndLower(t *testing.T) {
 		{"foo_bar", "F", "f"},
 		{"Foo.Bar", "F", "f"},
 		{"Foo1Bar", "F", "f"},
+		{"FooBar_", "F", "f"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.u, func(t *testing.T) {
-			if got := FirstCharUpper(tt.in); got != tt.u {
-				t.Errorf("FirstCharUpper(%q) = %q, want %q", tt.in, got, tt.u)
-			}
+			assert.Equal(t, tt.u, FirstCharUpper(tt.in))
 		})
 		t.Run(tt.l, func(t *testing.T) {
-			if got := FirstCharLower(tt.in); got != tt.l {
-				t.Errorf("FirstCharLower(%q) = %q, want %q", tt.in, got, tt.l)
-			}
+			assert.Equal(t, tt.l, FirstCharLower(tt.in))
 		})
 	}
 }
@@ -111,12 +109,11 @@ func TestJoin(t *testing.T) {
 		{[]string{"foo", "bar"}, "_", "foo_bar"},
 		{[]string{"foo", "bar"}, ".", "foo.bar"},
 		{[]string{"foo", "bar"}, "1", "foo1bar"},
+		{[]string{"foo_", "bar_"}, "", "foo_bar_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.out, func(t *testing.T) {
-			if got := Join(tt.sep, tt.in); got != tt.out {
-				t.Errorf("Join(%q, %q) = %q, want %q", tt.in, tt.sep, got, tt.out)
-			}
+			assert.Equal(t, tt.out, Join(tt.sep, tt.in))
 		})
 	}
 }
@@ -136,12 +133,11 @@ func TestTrimPrefix(t *testing.T) {
 		{"foo_bar", "foo", "_bar"},
 		{"foo.bar", "foo", ".bar"},
 		{"foo1bar", "foo", "1bar"},
+		{"fooBar_", "foo", "Bar_"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.out, func(t *testing.T) {
-			if got := TrimPrefix(tt.in, tt.prefix); got != tt.out {
-				t.Errorf("TrimPrefix(%q, %q) = %q, want %q", tt.in, tt.prefix, got, tt.out)
-			}
+			assert.Equal(t, tt.out, TrimPrefix(tt.in, tt.prefix))
 		})
 	}
 }
@@ -161,12 +157,11 @@ func TestTrimSuffix(t *testing.T) {
 		{"foo_bar", "_bar", "foo"},
 		{"foo.bar", ".bar", "foo"},
 		{"foo1bar", "1bar", "foo"},
+		{"fooBar_", "Bar_", "foo"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.out, func(t *testing.T) {
-			if got := TrimSuffix(tt.in, tt.suffix); got != tt.out {
-				t.Errorf("TrimSuffix(%q, %q) = %q, want %q", tt.in, tt.suffix, got, tt.out)
-			}
+			assert.Equal(t, tt.out, TrimSuffix(tt.in, tt.suffix))
 		})
 	}
 }
@@ -192,9 +187,7 @@ func TestReplace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.out, func(t *testing.T) {
-			if got := Replace(tt.in, tt.old, tt.new); got != tt.out {
-				t.Errorf("Replace(%q, %q, %q) = %q, want %q", tt.in, tt.old, tt.new, got, tt.out)
-			}
+			assert.Equal(t, tt.out, Replace(tt.in, tt.old, tt.new))
 		})
 	}
 }

--- a/pkg/gen/filters/filtergo/go_param.go
+++ b/pkg/gen/filters/filtergo/go_param.go
@@ -3,6 +3,7 @@ package filtergo
 import (
 	"fmt"
 
+	"github.com/apigear-io/cli/pkg/gen/filters/common"
 	"github.com/apigear-io/cli/pkg/model"
 )
 
@@ -10,6 +11,7 @@ func ToParamString(prefix string, schema *model.Schema, name string) (string, er
 	if schema == nil {
 		return "xxx", fmt.Errorf("ToParamString schema is nil")
 	}
+	name = common.CamelLowerCase(name)
 	if schema.IsImported() {
 		prefix = fmt.Sprintf("%s.", schema.ShortImportName())
 	}

--- a/pkg/gen/filters/filtergo/go_param_test.go
+++ b/pkg/gen/filters/filtergo/go_param_test.go
@@ -24,9 +24,9 @@ func TestParam(t *testing.T) {
 		{"test", "Test1", "propIntArray", "propIntArray []int32"},
 		{"test", "Test1", "propFloatArray", "propFloatArray []float32"},
 		{"test", "Test1", "propStringArray", "propStringArray []string"},
-		{"test", "Test1", "prop_Bool", "prop_Bool bool"},
-		{"test", "Test1", "prop_bool", "prop_bool bool"},
-		{"test", "Test1", "prop_1", "prop_1 bool"},
+		{"test", "Test1", "prop_Bool", "propBool bool"},
+		{"test", "Test1", "prop_bool", "propBool bool"},
+		{"test", "Test1", "prop_1", "prop1 bool"},
 	}
 	syss := loadTestSystems(t)
 	for _, sys := range syss {

--- a/pkg/gen/filters/filtergo/go_params_test.go
+++ b/pkg/gen/filters/filtergo/go_params_test.go
@@ -30,9 +30,9 @@ func TestParams(t *testing.T) {
 		{"test", "Test3", "opFloat32Array", "param1 []float32"},
 		{"test", "Test3", "opFloat64Array", "param1 []float64"},
 		{"test", "Test3", "opStringArray", "param1 []string"},
-		{"test", "Test3", "op_Bool", "param_Bool bool"},
-		{"test", "Test3", "op_bool", "param_bool bool"},
-		{"test", "Test3", "op_1", "param_1 bool"},
+		{"test", "Test3", "op_Bool", "paramBool bool"},
+		{"test", "Test3", "op_bool", "paramBool bool"},
+		{"test", "Test3", "op_1", "param1 bool"},
 	}
 	syss := loadTestSystems(t)
 	for _, sys := range syss {

--- a/pkg/model/base.go
+++ b/pkg/model/base.go
@@ -199,5 +199,5 @@ func (t TypedNode) TypeName() string {
 }
 
 func (t *TypedNode) CheckReservedWords(langs []rkw.Lang) {
-	rkw.CheckIsReserved(langs, t.Name, "type")
+	t.NamedNode.Name = rkw.CheckAndEscapeName(t.Name, "type")
 }

--- a/pkg/model/enum.go
+++ b/pkg/model/enum.go
@@ -73,7 +73,7 @@ func (e *Enum) NoMembers() bool {
 
 // CheckReservedWords checks the names of the enum.
 func (e *Enum) CheckReservedWords(langs []rkw.Lang) {
-	rkw.CheckIsReserved(langs, e.Name, "enum")
+	e.Name = rkw.CheckAndEscapeName(e.Name, "enum")
 	for _, mem := range e.Members {
 		mem.CheckReservedWords(langs)
 	}
@@ -103,5 +103,5 @@ func (e *EnumMember) Validate(m *Module) error {
 
 // CheckReservedWords checks the names of the enum member.
 func (e *EnumMember) CheckReservedWords(langs []rkw.Lang) {
-	rkw.CheckIsReserved(langs, e.Name, "enum member")
+	e.Name = rkw.CheckAndEscapeName(e.Name, "enum member")
 }

--- a/pkg/model/iface.go
+++ b/pkg/model/iface.go
@@ -35,7 +35,7 @@ func (s *Signal) Validate(m *Module) error {
 }
 
 func (s *Signal) CheckReservedWords(langs []rkw.Lang) {
-	rkw.CheckIsReserved(langs, s.Name, "signal")
+	s.Name = rkw.CheckAndEscapeName(s.Name, "signal")
 	for _, p := range s.Params {
 		p.CheckReservedWords(langs)
 	}
@@ -89,7 +89,7 @@ func (m *Operation) ParamNames() []string {
 }
 
 func (m *Operation) CheckReservedWords(langs []rkw.Lang) {
-	rkw.CheckIsReserved(langs, m.Name, "operation")
+	m.Name = rkw.CheckAndEscapeName(m.Name, "operation")
 	for _, p := range m.Params {
 		p.CheckReservedWords(langs)
 	}
@@ -234,7 +234,7 @@ func (i Interface) NoMembers() bool {
 }
 
 func (i *Interface) CheckReservedWords(langs []rkw.Lang) {
-	rkw.CheckIsReserved(langs, i.Name, "interface")
+	i.Name = rkw.CheckAndEscapeName(i.Name, "interface")
 	for _, p := range i.Properties {
 		p.CheckReservedWords(langs)
 	}

--- a/pkg/model/module.go
+++ b/pkg/model/module.go
@@ -334,7 +334,7 @@ func (m *Module) computeChecksum() {
 }
 
 func (m *Module) CheckReservedWords(langs []rkw.Lang) {
-	rkw.CheckIsReserved(langs, m.Name, "module")
+	m.Name = rkw.CheckAndEscapeName(m.Name, "module")
 	for _, i := range m.Interfaces {
 		i.CheckReservedWords(langs)
 	}

--- a/pkg/model/struct.go
+++ b/pkg/model/struct.go
@@ -55,7 +55,7 @@ func (s *Struct) NoFields() bool {
 }
 
 func (s *Struct) CheckReservedWords(langs []rkw.Lang) {
-	rkw.CheckIsReserved(langs, s.Name, "struct")
+	s.Name = rkw.CheckAndEscapeName(s.Name, "struct")
 	for _, f := range s.Fields {
 		f.CheckReservedWords(langs)
 	}

--- a/pkg/model/system.go
+++ b/pkg/model/system.go
@@ -246,11 +246,12 @@ func FQNSplit3(fqn string) (string, string, string) {
 }
 
 func (s *System) CheckReservedWords(langs []string) {
+	log.Info().Msgf("check system %s for reserved words", s.Name)
 	ls := make([]rkw.Lang, 0)
 	for _, l := range langs {
 		ls = append(ls, rkw.Lang(l))
 	}
-	rkw.CheckIsReserved(ls, s.Name, "system")
+	s.Name = rkw.CheckAndEscapeName(s.Name, "system")
 	for _, m := range s.Modules {
 		m.CheckReservedWords(ls)
 	}

--- a/pkg/spec/rkw/reserved.go
+++ b/pkg/spec/rkw/reserved.go
@@ -238,8 +238,9 @@ func CheckIsReserved(langs []Lang, name string, scope string) {
 func CheckAndEscapeName(name string, scope string) string {
 	langs, ok := IsKeywordReserved(name)
 	if ok {
-		log.Warn().Msgf("%s name \"%s\" is a reserved keyword in %s", scope, name, langs)
-		return EscapeKeyword(name)
+		word := EscapeKeyword(name)
+		log.Warn().Msgf("\"%s\" is a reserved keyword in %s. Escaped to \"%s\"", name, langs, word)
+		return word
 	}
 	return name
 }


### PR DESCRIPTION
When a reserved keyword is used, we now will change the <name> into <name_> during parsing of the model. Now we also need to ensure that the filters don't remove the `_` suffix. 
We still display a warning that the word is a reserved word.

So a name `switch` will be `switch_`. This would also impact json serialization (`switch_`) as property name. 

This solution could be used to ensure that on all technologies all names will be coherent and we should have almost never breaking code, based on reserved keywords. 