### PR TITLE
feat(qt): add test value filter for qt

### DIFF
--- a/pkg/gen/filters/filterqt/filters.go
+++ b/pkg/gen/filters/filterqt/filters.go
@@ -16,4 +16,5 @@ func PopulateFuncMap(fm template.FuncMap) {
 	fm["qtNamespace"] = qtNamespace
 	fm["qtExtern"] = qtExtern
 	fm["qtExterns"] = qtExterns
+	fm["qtTestValue"] = qtTestValue
 }

--- a/pkg/gen/filters/filterqt/qt_testvalue.go
+++ b/pkg/gen/filters/filterqt/qt_testvalue.go
@@ -1,0 +1,99 @@
+package filterqt
+
+import (
+	"fmt"
+
+	"github.com/apigear-io/cli/pkg/gen/filters/common"
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+// ToTestValueString returns the test value string for a given schema.
+// We intentionally ignore arrays in order to return the test value of the inner type.
+func ToTestValueString(prefix string, schema *model.Schema) (string, error) {
+	if schema == nil {
+		return "xxx", fmt.Errorf("pyTestValue schema is nil")
+	}
+	if schema.Module == nil {
+		return "xxx", fmt.Errorf("pyTestValue schema module is nil")
+	}
+	var text string
+	switch schema.KindType {
+	case model.TypeString:
+		text = "QString(\"xyz\")"
+	case model.TypeInt, model.TypeInt32:
+		text = "1"
+	case model.TypeInt64:
+		text = "1LL"
+	case model.TypeFloat, model.TypeFloat32:
+		text = "1.1f"
+	case model.TypeFloat64:
+		text = "1.1"
+	case model.TypeBool:
+		text = "true"
+	case model.TypeVoid:
+		return ToDefaultString(prefix, schema)
+	case model.TypeEnum:
+		e_local := schema.LookupEnum("", schema.Type)
+		e_imported := schema.LookupEnum(schema.Import, schema.Type)
+		if e_local == nil && e_imported == nil {
+			return "xxx", fmt.Errorf("qtTestValue enum not found: %s", schema.Dump())
+		}
+		// if enum is local it is found both as e_local and e_imported
+		name := e_imported.Name
+		member := common.UpperFirst(e_imported.Members[0].Name)
+		if len(e_imported.Members) > 1 {
+			member = common.UpperFirst(e_imported.Members[1].Name)
+		}
+		if e_local == nil {
+			prefix = fmt.Sprintf("%s::", qtNamespace(e_imported.Module.Name))
+		}
+		text = fmt.Sprintf("%s%s::%s", prefix, name, member)
+	// all types return deafualt value, but cannot be passed to deafult filter
+	// due to variants with array. Here we want to return default element, not deafult empty array.
+	case model.TypeStruct:
+		s_local := schema.LookupStruct("", schema.Type)
+		s_imported := schema.LookupStruct(schema.Import, schema.Type)
+		if s_local == nil && s_imported == nil {
+			return "xxx", fmt.Errorf("qtTestValue struct not found: %s", schema.Dump())
+		}
+		// if struct is local it is found both as s_local and s_imported
+		name := s_imported.Name
+		if s_local == nil {
+			prefix = fmt.Sprintf("%s::", qtNamespace(s_imported.Module.Name))
+		}
+		text = fmt.Sprintf("%s%s()", prefix, name)
+	case model.TypeExtern:
+		xe := parseQtExtern(schema)
+		if xe.Default != "" {
+			text = xe.Default
+		} else {
+			namespace_prefix := ""
+			if xe.NameSpace != "" {
+				namespace_prefix = fmt.Sprintf("%s::", xe.NameSpace)
+			}
+			text = fmt.Sprintf("%s%s()", namespace_prefix, xe.Name)
+		}
+	case model.TypeInterface:
+		i_local := schema.LookupInterface("", schema.Type)
+		i_imported := schema.LookupInterface(schema.Import, schema.Type)
+		if i_local == nil && i_imported == nil {
+			return "xxx", fmt.Errorf("qtTestValue interface not found: %s", schema.Dump())
+		}
+		// if interface is local it is found both as s_local and s_imported
+		name := i_imported.Name
+		if i_local == nil {
+			prefix = fmt.Sprintf("%s::", qtNamespace(i_imported.Module.Name))
+		}
+		text = fmt.Sprintf("%s%s()", prefix, name)
+	default:
+		return "xxx", fmt.Errorf("pyTestValue unknown schema %s", schema.Dump())
+	}
+	return text, nil
+}
+
+func qtTestValue(prefix string, node *model.TypedNode) (string, error) {
+	if node == nil {
+		return "xxx", fmt.Errorf("qtTestValue node is nil")
+	}
+	return ToTestValueString(prefix, &node.Schema)
+}

--- a/pkg/gen/filters/filterqt/qt_testvalue_test.go
+++ b/pkg/gen/filters/filterqt/qt_testvalue_test.go
@@ -1,0 +1,187 @@
+package filterqt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// test with all the types
+// properties, operation params, operation return, signal params, struct fields
+func TestTestValueFromIdl(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test1", "propVoid", "void"},
+		{"test", "Test1", "propBool", "true"},
+		{"test", "Test1", "propInt", "1"},
+		{"test", "Test1", "propInt32", "1"},
+		{"test", "Test1", "propInt64", "1LL"},
+		{"test", "Test1", "propFloat", "1.1f"},
+		{"test", "Test1", "propFloat32", "1.1f"},
+		{"test", "Test1", "propFloat64", "1.1"},
+		{"test", "Test1", "propString", "QString(\"xyz\")"},
+		{"test", "Test1", "propBoolArray", "true"}, // all the array types return value intentionally, it may be put into empty array
+		{"test", "Test1", "propIntArray", "1"},
+		{"test", "Test1", "propInt32Array", "1"},
+		{"test", "Test1", "propInt64Array", "1LL"},
+		{"test", "Test1", "propFloatArray", "1.1f"},
+		{"test", "Test1", "propFloat32Array", "1.1f"},
+		{"test", "Test1", "propFloat64Array", "1.1"},
+		{"test", "Test1", "propStringArray", "QString(\"xyz\")"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := qtTestValue("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestTestValueSymbolsFromIdl(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test2", "propEnum", "Enum1::NotDefault"},
+		{"test", "InterfaceNamesCheck", "lowerEnumProp", "EnumLowerNames::SecondValue"},
+		{"test", "Test2", "propStruct", "Struct1()"},
+		{"test", "Test2", "propInterface", "Interface1()"},
+		{"test", "Test2", "propEnumArray", "Enum1::NotDefault"},
+		{"test", "Test2", "propStructArray", "Struct1()"},
+		{"test", "Test2", "propInterfaceArray", "Interface1()"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := qtTestValue("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestTestValueWithErrors(t *testing.T) {
+	t.Parallel()
+	s, err := qtTestValue("", nil)
+	assert.Error(t, err)
+	assert.Equal(t, "xxx", s)
+}
+
+func TestTestValueFromIdlWithPrefix_makesNoDifference(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test1", "propVoid", "void"},
+		{"test", "Test1", "propBool", "true"},
+		{"test", "Test1", "propInt", "1"},
+		{"test", "Test1", "propInt32", "1"},
+		{"test", "Test1", "propInt64", "1LL"},
+		{"test", "Test1", "propFloat", "1.1f"},
+		{"test", "Test1", "propFloat32", "1.1f"},
+		{"test", "Test1", "propFloat64", "1.1"},
+		{"test", "Test1", "propString", "QString(\"xyz\")"},
+		{"test", "Test1", "propBoolArray", "true"}, // all the array types return value intentionally, it may be put into empty array
+		{"test", "Test1", "propIntArray", "1"},
+		{"test", "Test1", "propInt32Array", "1"},
+		{"test", "Test1", "propInt64Array", "1LL"},
+		{"test", "Test1", "propFloatArray", "1.1f"},
+		{"test", "Test1", "propFloat32Array", "1.1f"},
+		{"test", "Test1", "propFloat64Array", "1.1"},
+		{"test", "Test1", "propStringArray", "QString(\"xyz\")"},
+	}
+	prefix := "my_prefix::"
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := qtTestValue(prefix, prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestTestValueSymbolsFromIdlWithPrefix(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test2", "propEnum", "my_prefix::Enum1::NotDefault"},
+		{"test", "Test2", "propStruct", "my_prefix::Struct1()"},
+		{"test", "Test2", "propInterface", "my_prefix::Interface1()"},
+		{"test", "Test2", "propEnumArray", "my_prefix::Enum1::NotDefault"},
+		{"test", "Test2", "propStructArray", "my_prefix::Struct1()"},
+		{"test", "Test2", "propInterfaceArray", "my_prefix::Interface1()"},
+	}
+	prefix := "my_prefix::"
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := qtTestValue(prefix, prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestTestValueExterns(t *testing.T) {
+	t.Parallel()
+	table := []struct {
+		module_name    string
+		interface_name string
+		operation_name string
+		result         string
+	}{
+		{"test_apigear_next", "Iface1", "prop1", "XType1()"},
+		{"test_apigear_next", "Iface1", "prop2", "demoXA::XType2A()"},
+		{"test_apigear_next", "Iface1", "prop3", "demoXA::XTypeFactory::create()"},
+		{"test_apigear_next", "Iface1", "propList", "demoXA::XTypeFactory::create()"},
+		{"test_apigear_next", "Iface1", "propImportedEnum", "test::Enum1::NotDefault"},
+		{"test_apigear_next", "Iface1", "propImportedStruct", "test::Struct1()"},
+	}
+	syss := loadExternSystems(t)
+	prefix := "my_prefix::"
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.operation_name, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.module_name, tt.interface_name, tt.operation_name)
+				assert.NotNil(t, prop)
+				r, err := qtTestValue(prefix, prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.result, r)
+			})
+		}
+	}
+}


### PR DESCRIPTION
In Qt template we are missing some tests for our generated code.
With this filter, setting a property (signal value) different that
default can be generated. It allows us to test our generated interfaces
for which we use goldenmaster - the apis that cover hopefully most of
the uscases. Also provides generated tests for the users of ApiGear.
This filter is required to solve the https://github.com/apigear-io/cli/discussions/90 ticket https://github.com/apigear-io/cli/discussions/89 in template-qtcpp.