### PR TITLE
Refactor: rename UE enums to pascalcase

### DIFF
--- a/pkg/gen/filters/filterue/ue_default.go
+++ b/pkg/gen/filters/filterue/ue_default.go
@@ -3,6 +3,7 @@ package filterue
 import (
 	"fmt"
 
+	"github.com/apigear-io/cli/pkg/gen/filters/common"
 	"github.com/apigear-io/cli/pkg/helper"
 	"github.com/apigear-io/cli/pkg/model"
 	"github.com/ettle/strcase"
@@ -39,7 +40,7 @@ func ToDefaultString(prefix string, schema *model.Schema) (string, error) {
 		abbreviation := helper.Abbreviate(typename)
 		// upper case first letter
 		// TODO: EnumValues: using camel-cases for enum values: strcase.ToCamel(member.Name)
-		text = fmt.Sprintf("%sE%s::%s_%s", prefix, typename, abbreviation, strcase.ToCase(member.Name, strcase.UpperCase, '\x00'))
+		text = fmt.Sprintf("%sE%s::%s_%s", prefix, typename, abbreviation, common.CamelTitleCase(member.Name))
 	case model.TypeStruct:
 		symbol := schema.GetStruct()
 		text = fmt.Sprintf("%sF%s%s()", prefix, moduleId, symbol.Name)

--- a/pkg/gen/filters/filterue/ue_default_test.go
+++ b/pkg/gen/filters/filterue/ue_default_test.go
@@ -57,7 +57,7 @@ func TestDefaultSymbolsFromIdl(t *testing.T) {
 		val string
 	}{
 		// EnumValues: {"test", "Test2", "propEnum", "ETestEnum1::Default"},
-		{"test", "Test2", "propEnum", "ETestEnum1::TE1_DEFAULT"},
+		{"test", "Test2", "propEnum", "ETestEnum1::TE1_Default"},
 		{"test", "Test2", "propStruct", "FTestStruct1()"},
 		{"test", "Test2", "propInterface", "FTestInterface1()"},
 		{"test", "Test2", "propEnumArray", "TArray<ETestEnum1>()"},

--- a/pkg/gen/filters/filterue/ue_testvalue.go
+++ b/pkg/gen/filters/filterue/ue_testvalue.go
@@ -3,6 +3,7 @@ package filterue
 import (
 	"fmt"
 
+	"github.com/apigear-io/cli/pkg/gen/filters/common"
 	"github.com/apigear-io/cli/pkg/helper"
 	"github.com/apigear-io/cli/pkg/model"
 	"github.com/ettle/strcase"
@@ -44,7 +45,7 @@ func ToTestValueString(prefix string, schema *model.Schema) (string, error) {
 		abbreviation := helper.Abbreviate(typename)
 		// upper case first letter
 		// TODO: EnumValues: using camel-cases for enum values: strcase.ToCamel(member.Name)
-		text = fmt.Sprintf("%sE%s::%s_%s", prefix, typename, abbreviation, strcase.ToCase(member.Name, strcase.UpperCase, '\x00'))
+		text = fmt.Sprintf("%sE%s::%s_%s", prefix, typename, abbreviation, common.CamelTitleCase(member.Name))
 	case model.TypeStruct:
 		symbol := schema.GetStruct()
 		text = fmt.Sprintf("%sF%s%s()", prefix, moduleId, symbol.Name)

--- a/pkg/gen/filters/filterue/ue_testvalue_test.go
+++ b/pkg/gen/filters/filterue/ue_testvalue_test.go
@@ -57,10 +57,10 @@ func TestTestValueSymbolsFromIdl(t *testing.T) {
 		val string
 	}{
 		// EnumValues: {"test", "Test2", "propEnum", "ETestEnum1::Default"},
-		{"test", "Test2", "propEnum", "ETestEnum1::TE1_NOTDEFAULT"},
+		{"test", "Test2", "propEnum", "ETestEnum1::TE1_NotDefault"},
 		{"test", "Test2", "propStruct", "FTestStruct1()"},
 		{"test", "Test2", "propInterface", "FTestInterface1()"},
-		{"test", "Test2", "propEnumArray", "ETestEnum1::TE1_NOTDEFAULT"},
+		{"test", "Test2", "propEnumArray", "ETestEnum1::TE1_NotDefault"},
 		{"test", "Test2", "propStructArray", "FTestStruct1()"},
 		{"test", "Test2", "propInterfaceArray", "FTestInterface1()"},
 	}


### PR DESCRIPTION
## 📑 Description
- change the enum naming style to be pascalcase instead of all uppercase

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->