### PR TITLE
fix(cli): make sure env var is used if set

### DIFF
--- a/pkg/cfg/api.go
+++ b/pkg/cfg/api.go
@@ -2,7 +2,6 @@ package cfg
 
 import (
 	"fmt"
-	"log"
 	"path/filepath"
 )
 
@@ -86,11 +85,7 @@ func RecentEntries() []string {
 func SetBuildInfo(name string, info BuildInfo) {
 	rw.Lock()
 	v.Set("build."+name, info)
-	err := v.WriteConfig()
 	rw.Unlock()
-	if err != nil {
-		log.Printf("error writing config: %v", err)
-	}
 }
 
 func GetBuildInfo(name string) BuildInfo {

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -59,7 +59,6 @@ func NewConfig(cfgDir string) (*viper.Viper, error) {
 	nv.AutomaticEnv() // read in environment variables that match
 
 	cacheDir := helper.Join(cfgDir, "cache")
-	nv.Set(KeyCacheDir, cacheDir)
 
 	err := helper.MakeDir(cacheDir)
 	if err != nil {
@@ -67,13 +66,13 @@ func NewConfig(cfgDir string) (*viper.Viper, error) {
 	}
 
 	registryDir := helper.Join(cfgDir, "registry")
-	nv.Set(KeyRegistryDir, registryDir)
 
 	err = helper.MakeDir(registryDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create registry dir: %w", err)
 	}
 
+	nv.SetDefault(KeyCacheDir, cacheDir)
 	nv.SetDefault(KeyRegistryUrl, registryUrl)
 	nv.SetDefault(KeyRegistryDir, registryDir)
 	nv.SetDefault(KeyServerPort, 4333)


### PR DESCRIPTION
## 📑 Description
The contents of cacheDir and registryDir were overwritten by accident.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->