### PR TITLE
fix ci issues identified by golangci-lint

### DIFF
--- a/pkg/cmd/mon/run.go
+++ b/pkg/cmd/mon/run.go
@@ -19,16 +19,17 @@ func NewServerCommand() *cobra.Command {
 			opts := net.Options{
 				HttpAddr: addr,
 			}
-			netman.Start(&opts)
+			err := netman.Start(&opts)
+			if err != nil {
+				return err
+			}
 			netman.MonitorEmitter().AddHook(func(e *mon.Event) {
 				log.Info().Msgf("event: %s %s %v", e.Type.String(), e.Source, e.Data)
 			})
 			netman.OnMonitorEvent(func(event *mon.Event) {
 				log.Info().Str("source", event.Source).Str("type", event.Type.String()).Str("symbol", event.Symbol).Any("data", event.Data).Msg("received monitor event")
 			})
-			netman.Wait(cmd.Context())
-
-			return nil
+			return netman.Wait(cmd.Context())
 		},
 	}
 	cmd.Flags().StringVarP(&addr, "addr", "a", "127.0.0.1:5555", "address to listen on")

--- a/pkg/gen/filters/filterjava/java_test_value.go
+++ b/pkg/gen/filters/filterjava/java_test_value.go
@@ -41,7 +41,7 @@ func ToTestValueString(prefix string, schema *model.Schema) (string, error) {
 		symbol := schema.GetStruct()
 		text = fmt.Sprintf("new %s%s()", prefix, symbol.Name)
 	case model.TypeExtern:
-		text = fmt.Sprintf("TODO EXTERN")
+		text = "TODO EXTERN"
 	case model.TypeInterface:
 		symbol := schema.GetInterface()
 		text = fmt.Sprintf("%s%s()", prefix, symbol.Name)

--- a/pkg/gen/filters/filterjni/jni_java_signature_param.go
+++ b/pkg/gen/filters/filterjni/jni_java_signature_param.go
@@ -20,7 +20,7 @@ func jniSignatureType(node *model.TypedNode) (string, error) {
 	}
 
 	var text string
-	switch node.Schema.KindType {
+	switch node.KindType {
 	case model.TypeString:
 		text = "Ljava/lang/String;"
 	case model.TypeInt:
@@ -41,32 +41,32 @@ func jniSignatureType(node *model.TypedNode) (string, error) {
 		text = "V"
 	// enums are expected to passed as integers
 	case model.TypeEnum:
-		e := node.Schema.LookupEnum(node.Schema.Import, node.Schema.Type)
+		e := node.LookupEnum(node.Import, node.Type)
 		if e != nil {
 			text = makeFullTypeName(e.Module.Name, e.Name)
 		} else {
-			return "xxx", fmt.Errorf("ToSignatureType interface not found %s", node.Schema.Dump())
+			return "xxx", fmt.Errorf("ToSignatureType interface not found %s", node.Dump())
 		}
 	case model.TypeStruct:
-		s := node.Schema.LookupStruct(node.Schema.Import, node.Schema.Type)
+		s := node.LookupStruct(node.Import, node.Type)
 		if s != nil {
 			text = makeFullTypeName(s.Module.Name, s.Name)
 		} else {
-			return "xxx", fmt.Errorf("ToSignatureType interface not found %s", node.Schema.Dump())
+			return "xxx", fmt.Errorf("ToSignatureType interface not found %s", node.Dump())
 		}
 	case model.TypeExtern:
-		return "xxx", fmt.Errorf("ToSignatureType TypeExtern not supported yet %s", node.Schema.Dump())
+		return "xxx", fmt.Errorf("ToSignatureType TypeExtern not supported yet %s", node.Dump())
 	case model.TypeInterface:
-		i := node.Schema.LookupInterface(node.Schema.Import, node.Schema.Type)
+		i := node.LookupInterface(node.Import, node.Type)
 		if i != nil {
 			text = makeFullTypeName(i.Module.Name, i.Name)
 		} else {
-			return "xxx", fmt.Errorf("ToSignatureType interface not found %s", node.Schema.Dump())
+			return "xxx", fmt.Errorf("ToSignatureType interface not found %s", node.Dump())
 		}
 	default:
-		return "xxx", fmt.Errorf("jniJavaSignatureParam unknown schema %s", node.Schema.Dump())
+		return "xxx", fmt.Errorf("jniJavaSignatureParam unknown schema %s", node.Dump())
 	}
-	if node.Schema.IsArray {
+	if node.IsArray {
 		text = fmt.Sprintf("[%s", text)
 	}
 	return text, nil

--- a/pkg/idl/parser_test.go
+++ b/pkg/idl/parser_test.go
@@ -58,11 +58,11 @@ func TestParseStruct(t *testing.T) {
 	assert.Equal(t, "Struct0", module.Structs[0].Name)
 	struct_ := module.Structs[0]
 	assert.Equal(t, "field0", struct_.Fields[0].Name)
-	assert.Equal(t, "bool", struct_.Fields[0].Schema.Type)
+	assert.Equal(t, "bool", struct_.Fields[0].Type)
 	assert.Equal(t, "field1", struct_.Fields[1].Name)
-	assert.Equal(t, "int", struct_.Fields[1].Schema.Type)
+	assert.Equal(t, "int", struct_.Fields[1].Type)
 	assert.Equal(t, "field2", struct_.Fields[2].Name)
-	assert.Equal(t, "float", struct_.Fields[2].Schema.Type)
+	assert.Equal(t, "float", struct_.Fields[2].Type)
 	assert.Equal(t, "field3", struct_.Fields[3].Name)
 	assert.Equal(t, "string", struct_.Fields[3].Type)
 	assert.Equal(t, "field4", struct_.Fields[4].Name)
@@ -117,21 +117,21 @@ func TestParseInterfaceOperation(t *testing.T) {
 	// operation1
 	assert.Equal(t, "operation0", iface.Operations[0].Name)
 	assert.Equal(t, "param0", iface.Operations[0].Params[0].Name)
-	assert.Equal(t, "bool", iface.Operations[0].Params[0].Schema.Type)
+	assert.Equal(t, "bool", iface.Operations[0].Params[0].Type)
 	// operation2
 	assert.Equal(t, "operation1", iface.Operations[1].Name)
 	assert.Equal(t, "param0", iface.Operations[1].Params[0].Name)
-	assert.Equal(t, "bool", iface.Operations[1].Params[0].Schema.Type)
+	assert.Equal(t, "bool", iface.Operations[1].Params[0].Type)
 	assert.Equal(t, "param1", iface.Operations[1].Params[1].Name)
-	assert.Equal(t, "int", iface.Operations[1].Params[1].Schema.Type)
+	assert.Equal(t, "int", iface.Operations[1].Params[1].Type)
 	// operation3
 	assert.Equal(t, "operation2", iface.Operations[2].Name)
 	assert.Equal(t, "param0", iface.Operations[2].Params[0].Name)
-	assert.Equal(t, "bool", iface.Operations[2].Params[0].Schema.Type)
+	assert.Equal(t, "bool", iface.Operations[2].Params[0].Type)
 	assert.Equal(t, "param1", iface.Operations[2].Params[1].Name)
-	assert.Equal(t, "int", iface.Operations[2].Params[1].Schema.Type)
+	assert.Equal(t, "int", iface.Operations[2].Params[1].Type)
 	assert.Equal(t, "param2", iface.Operations[2].Params[2].Name)
-	assert.Equal(t, "float", iface.Operations[2].Params[2].Schema.Type)
+	assert.Equal(t, "float", iface.Operations[2].Params[2].Type)
 }
 
 func TestParseInterfaceSignal(t *testing.T) {
@@ -141,12 +141,12 @@ func TestParseInterfaceSignal(t *testing.T) {
 	interface_ := module.Interfaces[2]
 	assert.Equal(t, "signal0", interface_.Signals[0].Name)
 	assert.Equal(t, "param0", interface_.Signals[0].Params[0].Name)
-	assert.Equal(t, "bool", interface_.Signals[0].Params[0].Schema.Type)
+	assert.Equal(t, "bool", interface_.Signals[0].Params[0].Type)
 	assert.Equal(t, "signal1", interface_.Signals[1].Name)
 	assert.Equal(t, "param0", interface_.Signals[1].Params[0].Name)
-	assert.Equal(t, "bool", interface_.Signals[1].Params[0].Schema.Type)
+	assert.Equal(t, "bool", interface_.Signals[1].Params[0].Type)
 	assert.Equal(t, "param1", interface_.Signals[1].Params[1].Name)
-	assert.Equal(t, "int", interface_.Signals[1].Params[1].Schema.Type)
+	assert.Equal(t, "int", interface_.Signals[1].Params[1].Type)
 }
 
 var docSymbols = `
@@ -178,11 +178,11 @@ func TestParseSymbolProperties(t *testing.T) {
 	assert.Equal(t, "Interface0", iface0.Name)
 	iface1 := module.Interfaces[1]
 	assert.Equal(t, "prop0", iface1.Properties[0].Name)
-	assert.Equal(t, "Enum0", iface1.Properties[0].Schema.Type)
+	assert.Equal(t, "Enum0", iface1.Properties[0].Type)
 	assert.Equal(t, "prop1", iface1.Properties[1].Name)
-	assert.Equal(t, "Struct0", iface1.Properties[1].Schema.Type)
+	assert.Equal(t, "Struct0", iface1.Properties[1].Type)
 	assert.Equal(t, "prop2", iface1.Properties[2].Name)
-	assert.Equal(t, "Interface0", iface1.Properties[2].Schema.Type)
+	assert.Equal(t, "Interface0", iface1.Properties[2].Type)
 }
 
 func TestParseSymbolOperations(t *testing.T) {
@@ -195,13 +195,13 @@ func TestParseSymbolOperations(t *testing.T) {
 	iface1 := module.Interfaces[1]
 	assert.Equal(t, "operation0", iface1.Operations[0].Name)
 	assert.Equal(t, "param0", iface1.Operations[0].Params[0].Name)
-	assert.Equal(t, "Enum0", iface1.Operations[0].Params[0].Schema.Type)
+	assert.Equal(t, "Enum0", iface1.Operations[0].Params[0].Type)
 	assert.Equal(t, "operation1", iface1.Operations[1].Name)
 	assert.Equal(t, "param0", iface1.Operations[1].Params[0].Name)
-	assert.Equal(t, "Struct0", iface1.Operations[1].Params[0].Schema.Type)
+	assert.Equal(t, "Struct0", iface1.Operations[1].Params[0].Type)
 	assert.Equal(t, "operation2", iface1.Operations[2].Name)
 	assert.Equal(t, "param0", iface1.Operations[2].Params[0].Name)
-	assert.Equal(t, "Interface0", iface1.Operations[2].Params[0].Schema.Type)
+	assert.Equal(t, "Interface0", iface1.Operations[2].Params[0].Type)
 }
 
 func TestParseSymbolSignals(t *testing.T) {
@@ -214,13 +214,13 @@ func TestParseSymbolSignals(t *testing.T) {
 	iface1 := module.Interfaces[1]
 	assert.Equal(t, "signal0", iface1.Signals[0].Name)
 	assert.Equal(t, "param0", iface1.Signals[0].Params[0].Name)
-	assert.Equal(t, "Enum0", iface1.Signals[0].Params[0].Schema.Type)
+	assert.Equal(t, "Enum0", iface1.Signals[0].Params[0].Type)
 	assert.Equal(t, "signal1", iface1.Signals[1].Name)
 	assert.Equal(t, "param0", iface1.Signals[1].Params[0].Name)
-	assert.Equal(t, "Struct0", iface1.Signals[1].Params[0].Schema.Type)
+	assert.Equal(t, "Struct0", iface1.Signals[1].Params[0].Type)
 	assert.Equal(t, "signal2", iface1.Signals[2].Name)
 	assert.Equal(t, "param0", iface1.Signals[2].Params[0].Name)
-	assert.Equal(t, "Interface0", iface1.Signals[2].Params[0].Schema.Type)
+	assert.Equal(t, "Interface0", iface1.Signals[2].Params[0].Type)
 }
 
 var docPrimitiveArrays = `
@@ -254,20 +254,20 @@ func TestPrimitiveArrayProperties(t *testing.T) {
 	assert.Equal(t, "Interface0", iface0.Name)
 	iface1 := module.Interfaces[1]
 	assert.Equal(t, "prop0", iface1.Properties[0].Name)
-	assert.Equal(t, "bool", iface1.Properties[0].Schema.Type)
-	assert.True(t, iface1.Properties[0].Schema.IsArray)
+	assert.Equal(t, "bool", iface1.Properties[0].Type)
+	assert.True(t, iface1.Properties[0].IsArray)
 	assert.Equal(t, "prop1", iface1.Properties[1].Name)
-	assert.Equal(t, "int", iface1.Properties[1].Schema.Type)
-	assert.True(t, iface1.Properties[1].Schema.IsArray)
+	assert.Equal(t, "int", iface1.Properties[1].Type)
+	assert.True(t, iface1.Properties[1].IsArray)
 	assert.Equal(t, "prop2", iface1.Properties[2].Name)
-	assert.Equal(t, "float", iface1.Properties[2].Schema.Type)
-	assert.True(t, iface1.Properties[2].Schema.IsArray)
+	assert.Equal(t, "float", iface1.Properties[2].Type)
+	assert.True(t, iface1.Properties[2].IsArray)
 	assert.Equal(t, "prop3", iface1.Properties[3].Name)
-	assert.Equal(t, "string", iface1.Properties[3].Schema.Type)
-	assert.True(t, iface1.Properties[3].Schema.IsArray)
+	assert.Equal(t, "string", iface1.Properties[3].Type)
+	assert.True(t, iface1.Properties[3].IsArray)
 	assert.Equal(t, "prop4", iface1.Properties[4].Name)
-	assert.Equal(t, "bytes", iface1.Properties[4].Schema.Type)
-	assert.True(t, iface1.Properties[4].Schema.IsArray)
+	assert.Equal(t, "bytes", iface1.Properties[4].Type)
+	assert.True(t, iface1.Properties[4].IsArray)
 }
 
 func TestPrimitiveArrayOperations(t *testing.T) {
@@ -280,24 +280,24 @@ func TestPrimitiveArrayOperations(t *testing.T) {
 	iface1 := module.Interfaces[1]
 	assert.Equal(t, "operation0", iface1.Operations[0].Name)
 	assert.Equal(t, "param0", iface1.Operations[0].Params[0].Name)
-	assert.Equal(t, "bool", iface1.Operations[0].Params[0].Schema.Type)
-	assert.True(t, iface1.Operations[0].Params[0].Schema.IsArray)
+	assert.Equal(t, "bool", iface1.Operations[0].Params[0].Type)
+	assert.True(t, iface1.Operations[0].Params[0].IsArray)
 	assert.Equal(t, "operation1", iface1.Operations[1].Name)
 	assert.Equal(t, "param0", iface1.Operations[1].Params[0].Name)
-	assert.Equal(t, "int", iface1.Operations[1].Params[0].Schema.Type)
-	assert.True(t, iface1.Operations[1].Params[0].Schema.IsArray)
+	assert.Equal(t, "int", iface1.Operations[1].Params[0].Type)
+	assert.True(t, iface1.Operations[1].Params[0].IsArray)
 	assert.Equal(t, "operation2", iface1.Operations[2].Name)
 	assert.Equal(t, "param0", iface1.Operations[2].Params[0].Name)
-	assert.Equal(t, "float", iface1.Operations[2].Params[0].Schema.Type)
-	assert.True(t, iface1.Operations[2].Params[0].Schema.IsArray)
+	assert.Equal(t, "float", iface1.Operations[2].Params[0].Type)
+	assert.True(t, iface1.Operations[2].Params[0].IsArray)
 	assert.Equal(t, "operation3", iface1.Operations[3].Name)
 	assert.Equal(t, "param0", iface1.Operations[3].Params[0].Name)
-	assert.Equal(t, "string", iface1.Operations[3].Params[0].Schema.Type)
-	assert.True(t, iface1.Operations[3].Params[0].Schema.IsArray)
+	assert.Equal(t, "string", iface1.Operations[3].Params[0].Type)
+	assert.True(t, iface1.Operations[3].Params[0].IsArray)
 	assert.Equal(t, "operation4", iface1.Operations[4].Name)
 	assert.Equal(t, "param0", iface1.Operations[4].Params[0].Name)
-	assert.Equal(t, "bytes", iface1.Operations[4].Params[0].Schema.Type)
-	assert.True(t, iface1.Operations[4].Params[0].Schema.IsArray)
+	assert.Equal(t, "bytes", iface1.Operations[4].Params[0].Type)
+	assert.True(t, iface1.Operations[4].Params[0].IsArray)
 }
 
 func TestPrimitiveArraySignals(t *testing.T) {
@@ -312,32 +312,32 @@ func TestPrimitiveArraySignals(t *testing.T) {
 	input := signal.Params[0]
 	assert.Equal(t, "signal0", signal.Name)
 	assert.Equal(t, "param0", input.Name)
-	assert.Equal(t, "bool", input.Schema.Type)
-	assert.True(t, input.Schema.IsArray)
+	assert.Equal(t, "bool", input.Type)
+	assert.True(t, input.IsArray)
 	signal = iface1.Signals[1]
 	input = signal.Params[0]
 	assert.Equal(t, "signal1", signal.Name)
 	assert.Equal(t, "param0", input.Name)
-	assert.Equal(t, "int", input.Schema.Type)
-	assert.True(t, input.Schema.IsArray)
+	assert.Equal(t, "int", input.Type)
+	assert.True(t, input.IsArray)
 	signal = iface1.Signals[2]
 	input = signal.Params[0]
 	assert.Equal(t, "signal2", signal.Name)
 	assert.Equal(t, "param0", input.Name)
-	assert.Equal(t, "float", input.Schema.Type)
-	assert.True(t, input.Schema.IsArray)
+	assert.Equal(t, "float", input.Type)
+	assert.True(t, input.IsArray)
 	signal = iface1.Signals[3]
 	input = signal.Params[0]
 	assert.Equal(t, "signal3", signal.Name)
 	assert.Equal(t, "param0", input.Name)
-	assert.Equal(t, "string", input.Schema.Type)
-	assert.True(t, input.Schema.IsArray)
+	assert.Equal(t, "string", input.Type)
+	assert.True(t, input.IsArray)
 	signal = iface1.Signals[4]
 	input = signal.Params[0]
 	assert.Equal(t, "signal4", signal.Name)
 	assert.Equal(t, "param0", input.Name)
-	assert.Equal(t, "bytes", input.Schema.Type)
-	assert.True(t, input.Schema.IsArray)
+	assert.Equal(t, "bytes", input.Type)
+	assert.True(t, input.IsArray)
 }
 
 var docSymbolArrays = `
@@ -370,16 +370,16 @@ func TestSymbolArrayProperties(t *testing.T) {
 	iface1 := module.Interfaces[1]
 	prop := iface1.Properties[0]
 	assert.Equal(t, "prop0", prop.Name)
-	assert.Equal(t, "Enum0", prop.Schema.Type)
-	assert.True(t, prop.Schema.IsArray)
+	assert.Equal(t, "Enum0", prop.Type)
+	assert.True(t, prop.IsArray)
 	prop = iface1.Properties[1]
 	assert.Equal(t, "prop1", prop.Name)
-	assert.Equal(t, "Struct0", prop.Schema.Type)
-	assert.True(t, prop.Schema.IsArray)
+	assert.Equal(t, "Struct0", prop.Type)
+	assert.True(t, prop.IsArray)
 	prop = iface1.Properties[2]
 	assert.Equal(t, "prop2", prop.Name)
-	assert.Equal(t, "Interface0", prop.Schema.Type)
-	assert.True(t, prop.Schema.IsArray)
+	assert.Equal(t, "Interface0", prop.Type)
+	assert.True(t, prop.IsArray)
 }
 
 func TestSymbolArrayOperations(t *testing.T) {
@@ -394,20 +394,20 @@ func TestSymbolArrayOperations(t *testing.T) {
 	input := op.Params[0]
 	assert.Equal(t, "operation0", op.Name)
 	assert.Equal(t, "param0", input.Name)
-	assert.Equal(t, "Enum0", input.Schema.Type)
-	assert.True(t, input.Schema.IsArray)
+	assert.Equal(t, "Enum0", input.Type)
+	assert.True(t, input.IsArray)
 	op = iface1.Operations[1]
 	input = op.Params[0]
 	assert.Equal(t, "operation1", op.Name)
 	assert.Equal(t, "param0", input.Name)
-	assert.Equal(t, "Struct0", input.Schema.Type)
-	assert.True(t, input.Schema.IsArray)
+	assert.Equal(t, "Struct0", input.Type)
+	assert.True(t, input.IsArray)
 	op = iface1.Operations[2]
 	input = op.Params[0]
 	assert.Equal(t, "operation2", op.Name)
 	assert.Equal(t, "param0", input.Name)
-	assert.Equal(t, "Interface0", input.Schema.Type)
-	assert.True(t, input.Schema.IsArray)
+	assert.Equal(t, "Interface0", input.Type)
+	assert.True(t, input.IsArray)
 }
 
 func TestSymbolArraySignals(t *testing.T) {
@@ -420,14 +420,14 @@ func TestSymbolArraySignals(t *testing.T) {
 	iface1 := module.Interfaces[1]
 	assert.Equal(t, "signal0", iface1.Signals[0].Name)
 	assert.Equal(t, "param0", iface1.Signals[0].Params[0].Name)
-	assert.Equal(t, "Enum0", iface1.Signals[0].Params[0].Schema.Type)
-	assert.True(t, iface1.Signals[0].Params[0].Schema.IsArray)
+	assert.Equal(t, "Enum0", iface1.Signals[0].Params[0].Type)
+	assert.True(t, iface1.Signals[0].Params[0].IsArray)
 	assert.Equal(t, "signal1", iface1.Signals[1].Name)
 	assert.Equal(t, "param0", iface1.Signals[1].Params[0].Name)
-	assert.Equal(t, "Struct0", iface1.Signals[1].Params[0].Schema.Type)
-	assert.True(t, iface1.Signals[2].Params[0].Schema.IsArray)
+	assert.Equal(t, "Struct0", iface1.Signals[1].Params[0].Type)
+	assert.True(t, iface1.Signals[2].Params[0].IsArray)
 	assert.Equal(t, "signal2", iface1.Signals[2].Name)
 	assert.Equal(t, "param0", iface1.Signals[2].Params[0].Name)
-	assert.Equal(t, "Interface0", iface1.Signals[2].Params[0].Schema.Type)
-	assert.True(t, iface1.Signals[2].Params[0].Schema.IsArray)
+	assert.Equal(t, "Interface0", iface1.Signals[2].Params[0].Type)
+	assert.True(t, iface1.Signals[2].Params[0].IsArray)
 }

--- a/pkg/model/iface_test.go
+++ b/pkg/model/iface_test.go
@@ -28,7 +28,7 @@ func TestProperties(t *testing.T) {
 	assert.Equal(t, 1, len(iface0.Properties))
 	prop0 := iface0.Properties[0]
 	assert.Equal(t, "prop01", prop0.Name)
-	assert.Equal(t, "bool", prop0.Schema.Type)
+	assert.Equal(t, "bool", prop0.Type)
 }
 
 func TestReadonlyProperties(t *testing.T) {
@@ -60,8 +60,8 @@ func TestOperations(t *testing.T) {
 	assert.Equal(t, "operation01", op0.Name)
 	assert.Equal(t, 1, len(op0.Params))
 	assert.Equal(t, "param01", op0.Params[0].Name)
-	assert.Equal(t, "bool", op0.Params[0].Schema.Type)
-	assert.Equal(t, "bool", op0.Return.Schema.Type)
+	assert.Equal(t, "bool", op0.Params[0].Type)
+	assert.Equal(t, "bool", op0.Return.Type)
 }
 
 const duplicatesYAML = `schema: apigear.module/1.0

--- a/pkg/model/visitor_test.go
+++ b/pkg/model/visitor_test.go
@@ -103,10 +103,8 @@ func TestVisitor(t *testing.T) {
 
 	// Create a mock visitor
 	mockVisitor := &MockVisitor{}
-	system.AcceptModelVisitor(mockVisitor)
-	if err != nil {
-		t.Errorf("AcceptModelVisitor returned an error: %v", err)
-	}
+	err = system.AcceptModelVisitor(mockVisitor)
+	assert.NoError(t, err)
 	// Check if all nodes were visited
 	assert.NotEmpty(t, mockVisitor.visited)
 	// Check if specific nodes were visited

--- a/pkg/prj/demos.go
+++ b/pkg/prj/demos.go
@@ -13,15 +13,20 @@ const (
 	DemoScenario DemoType = "scenario"
 )
 
-func writeDemo(target string, content []byte) error {
-	if _, err := os.Stat(target); err == nil {
+func writeDemo(target string, content []byte) (err error) {
+	if _, statErr := os.Stat(target); statErr == nil {
 		return fmt.Errorf("file %s already exists", target)
 	}
 	f, err := os.Create(target)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		cerr := f.Close()
+		if err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
 	_, err = f.Write(content)
 	return err
 }

--- a/pkg/sim/service_proxy_test.go
+++ b/pkg/sim/service_proxy_test.go
@@ -32,7 +32,7 @@ func TestServiceProxy(t *testing.T) {
 			assert.Equal(t, int64(42), countVal.Export())
 
 			// Test property set
-			proxy.Set("count", rt.ToValue(100))
+			require.NoError(t, proxy.Set("count", rt.ToValue(100)))
 			assert.Equal(t, int64(100), service.GetProperty("count"))
 
 			done <- true
@@ -58,7 +58,7 @@ func TestServiceProxy(t *testing.T) {
 				return rt.ToValue("success")
 			})
 
-			proxy.Set("testMethod", method)
+			require.NoError(t, proxy.Set("testMethod", method))
 			assert.True(t, service.HasMethod("testMethod"))
 
 			// Call the method through the proxy


### PR DESCRIPTION
- missing error checks
- fmt.Printf for static text
- Using inline structs
