### PR TITLE
feat(java): add list variant template filters

### DIFF
--- a/pkg/gen/filters/filterjava/filters.go
+++ b/pkg/gen/filters/filterjava/filters.go
@@ -14,4 +14,10 @@ func PopulateFuncMap(fm template.FuncMap) {
 	fm["javaAsyncReturn"] = javaAsyncReturn
 	fm["javaTestValue"] = javaTestValue
 	fm["javaElementType"] = javaElementType
+	fm["javaListReturn"] = javaListReturn
+	fm["javaListType"] = javaListType
+	fm["javaListParam"] = javaListParam
+	fm["javaListParams"] = javaListParams
+	fm["javaListDefault"] = javaListDefault
+	fm["javaListAsyncReturn"] = javaListAsyncReturn
 }

--- a/pkg/gen/filters/filterjava/java_boxed_type.go
+++ b/pkg/gen/filters/filterjava/java_boxed_type.go
@@ -1,0 +1,20 @@
+package filterjava
+
+// toBoxedType converts a primitive Java type name to its boxed equivalent.
+// Non-primitive types are returned unchanged.
+func toBoxedType(primitiveType string) string {
+	switch primitiveType {
+	case "int":
+		return "Integer"
+	case "long":
+		return "Long"
+	case "float":
+		return "Float"
+	case "double":
+		return "Double"
+	case "boolean":
+		return "Boolean"
+	default:
+		return primitiveType
+	}
+}

--- a/pkg/gen/filters/filterjava/java_list_async_return.go
+++ b/pkg/gen/filters/filterjava/java_list_async_return.go
@@ -1,0 +1,30 @@
+package filterjava
+
+import (
+	"fmt"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+func ToListAsyncReturnString(prefix string, schema *model.Schema) (string, error) {
+	if schema == nil {
+		return "xxx", fmt.Errorf("ToListAsyncReturnString schema is nil")
+	}
+	if !schema.IsArray {
+		return ToAsyncReturnString(prefix, schema)
+	}
+	inner := schema.InnerSchema()
+	elementType, err := ToReturnString(prefix, &inner)
+	if err != nil {
+		return "xxx", fmt.Errorf("javaListAsyncReturn element type error: %s", err)
+	}
+	boxed := toBoxedType(elementType)
+	return fmt.Sprintf("CompletableFuture<List<%s>>", boxed), nil
+}
+
+func javaListAsyncReturn(prefix string, node *model.TypedNode) (string, error) {
+	if node == nil {
+		return "xxx", fmt.Errorf("javaListAsyncReturn node is nil")
+	}
+	return ToListAsyncReturnString(prefix, &node.Schema)
+}

--- a/pkg/gen/filters/filterjava/java_list_async_return_test.go
+++ b/pkg/gen/filters/filterjava/java_list_async_return_test.go
@@ -1,0 +1,115 @@
+package filterjava
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListAsyncReturn(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test1", "propVoid", "CompletableFuture<Void>"},
+		{"test", "Test1", "propBool", "CompletableFuture<Boolean>"},
+		{"test", "Test1", "propInt", "CompletableFuture<Integer>"},
+		{"test", "Test1", "propInt32", "CompletableFuture<Integer>"},
+		{"test", "Test1", "propInt64", "CompletableFuture<Long>"},
+		{"test", "Test1", "propFloat", "CompletableFuture<Float>"},
+		{"test", "Test1", "propFloat32", "CompletableFuture<Float>"},
+		{"test", "Test1", "propFloat64", "CompletableFuture<Double>"},
+		{"test", "Test1", "propString", "CompletableFuture<String>"},
+		{"test", "Test1", "propBoolArray", "CompletableFuture<List<Boolean>>"},
+		{"test", "Test1", "propIntArray", "CompletableFuture<List<Integer>>"},
+		{"test", "Test1", "propInt32Array", "CompletableFuture<List<Integer>>"},
+		{"test", "Test1", "propInt64Array", "CompletableFuture<List<Long>>"},
+		{"test", "Test1", "propFloatArray", "CompletableFuture<List<Float>>"},
+		{"test", "Test1", "propFloat32Array", "CompletableFuture<List<Float>>"},
+		{"test", "Test1", "propFloat64Array", "CompletableFuture<List<Double>>"},
+		{"test", "Test1", "propStringArray", "CompletableFuture<List<String>>"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := javaListAsyncReturn("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestListAsyncOperationReturn(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test3", "opVoid", "CompletableFuture<Void>"},
+		{"test", "Test3", "opBool", "CompletableFuture<Boolean>"},
+		{"test", "Test3", "opInt", "CompletableFuture<Integer>"},
+		{"test", "Test3", "opInt32", "CompletableFuture<Integer>"},
+		{"test", "Test3", "opInt64", "CompletableFuture<Long>"},
+		{"test", "Test3", "opFloat", "CompletableFuture<Float>"},
+		{"test", "Test3", "opFloat32", "CompletableFuture<Float>"},
+		{"test", "Test3", "opFloat64", "CompletableFuture<Double>"},
+		{"test", "Test3", "opString", "CompletableFuture<String>"},
+		{"test", "Test3", "opBoolArray", "CompletableFuture<List<Boolean>>"},
+		{"test", "Test3", "opIntArray", "CompletableFuture<List<Integer>>"},
+		{"test", "Test3", "opInt32Array", "CompletableFuture<List<Integer>>"},
+		{"test", "Test3", "opInt64Array", "CompletableFuture<List<Long>>"},
+		{"test", "Test3", "opFloatArray", "CompletableFuture<List<Float>>"},
+		{"test", "Test3", "opFloat32Array", "CompletableFuture<List<Float>>"},
+		{"test", "Test3", "opFloat64Array", "CompletableFuture<List<Double>>"},
+		{"test", "Test3", "opStringArray", "CompletableFuture<List<String>>"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				op := sys.LookupOperation(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, op)
+				r, err := javaListAsyncReturn("", op.Return)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestListAsyncReturnExternsYaml(t *testing.T) {
+	t.Parallel()
+	table := []struct {
+		module_name    string
+		interface_name string
+		operation_name string
+		result         string
+	}{
+		{"test_apigear_next", "Iface1", "func1", "CompletableFuture<XType1>"},
+		{"test_apigear_next", "Iface1", "func3", "CompletableFuture<demo.x.XType3A>"},
+		{"test_apigear_next", "Iface1", "funcList", "CompletableFuture<List<demo.x.XType3A>>"},
+		{"test_apigear_next", "Iface1", "funcImportedEnum", "CompletableFuture<test.test_api.Enum1>"},
+		{"test_apigear_next", "Iface1", "funcImportedStruct", "CompletableFuture<test.test_api.Struct1>"},
+	}
+	syss := loadExternSystemsYAML(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.operation_name, func(t *testing.T) {
+				op := sys.LookupOperation(tt.module_name, tt.interface_name, tt.operation_name)
+				assert.NotNil(t, op)
+				r, err := javaListAsyncReturn("", op.Return)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.result, r)
+			})
+		}
+	}
+}

--- a/pkg/gen/filters/filterjava/java_list_default.go
+++ b/pkg/gen/filters/filterjava/java_list_default.go
@@ -1,0 +1,24 @@
+package filterjava
+
+import (
+	"fmt"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+func ToListDefaultString(schema *model.Schema, prefix string) (string, error) {
+	if schema == nil {
+		return "xxx", fmt.Errorf("ToListDefaultString schema is nil")
+	}
+	if !schema.IsArray {
+		return ToDefaultString(schema, prefix)
+	}
+	return "new ArrayList<>()", nil
+}
+
+func javaListDefault(prefix string, node *model.TypedNode) (string, error) {
+	if node == nil {
+		return "xxx", fmt.Errorf("javaListDefault node is nil")
+	}
+	return ToListDefaultString(&node.Schema, prefix)
+}

--- a/pkg/gen/filters/filterjava/java_list_default_test.go
+++ b/pkg/gen/filters/filterjava/java_list_default_test.go
@@ -1,0 +1,75 @@
+package filterjava
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListDefault(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test1", "propBool", "false"},
+		{"test", "Test1", "propInt", "0"},
+		{"test", "Test1", "propInt32", "0"},
+		{"test", "Test1", "propInt64", "0L"},
+		{"test", "Test1", "propFloat", "0.0f"},
+		{"test", "Test1", "propFloat32", "0.0f"},
+		{"test", "Test1", "propFloat64", "0.0"},
+		{"test", "Test1", "propString", "new String()"},
+		{"test", "Test1", "propBoolArray", "new ArrayList<>()"},
+		{"test", "Test1", "propIntArray", "new ArrayList<>()"},
+		{"test", "Test1", "propInt32Array", "new ArrayList<>()"},
+		{"test", "Test1", "propInt64Array", "new ArrayList<>()"},
+		{"test", "Test1", "propFloatArray", "new ArrayList<>()"},
+		{"test", "Test1", "propFloat32Array", "new ArrayList<>()"},
+		{"test", "Test1", "propFloat64Array", "new ArrayList<>()"},
+		{"test", "Test1", "propStringArray", "new ArrayList<>()"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := javaListDefault("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestListDefaultSymbols(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test2", "propEnum", "Enum1.Default"},
+		{"test", "Test2", "propStruct", "new Struct1()"},
+		{"test", "Test2", "propInterface", "null"},
+		{"test", "Test2", "propEnumArray", "new ArrayList<>()"},
+		{"test", "Test2", "propStructArray", "new ArrayList<>()"},
+		{"test", "Test2", "propInterfaceArray", "new ArrayList<>()"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := javaListDefault("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}

--- a/pkg/gen/filters/filterjava/java_list_param.go
+++ b/pkg/gen/filters/filterjava/java_list_param.go
@@ -1,0 +1,30 @@
+package filterjava
+
+import (
+	"fmt"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+func ToListParamString(prefix string, schema *model.Schema, name string) (string, error) {
+	if schema == nil {
+		return "xxx", fmt.Errorf("ToListParamString schema is nil")
+	}
+	if schema.IsArray {
+		inner := schema.InnerSchema()
+		elementType, err := ToReturnString(prefix, &inner)
+		if err != nil {
+			return "xxx", fmt.Errorf("javaListParam element type error: %s", err)
+		}
+		boxed := toBoxedType(elementType)
+		return fmt.Sprintf("List<%s> %s", boxed, name), nil
+	}
+	return ToParamString(prefix, schema, name)
+}
+
+func javaListParam(prefix string, node *model.TypedNode) (string, error) {
+	if node == nil {
+		return "xxx", fmt.Errorf("javaListParam node is nil")
+	}
+	return ToListParamString(prefix, &node.Schema, node.Name)
+}

--- a/pkg/gen/filters/filterjava/java_list_param_test.go
+++ b/pkg/gen/filters/filterjava/java_list_param_test.go
@@ -1,0 +1,75 @@
+package filterjava
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListParam(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test1", "propBool", "boolean propBool"},
+		{"test", "Test1", "propInt", "int propInt"},
+		{"test", "Test1", "propInt32", "int propInt32"},
+		{"test", "Test1", "propInt64", "long propInt64"},
+		{"test", "Test1", "propFloat", "float propFloat"},
+		{"test", "Test1", "propFloat32", "float propFloat32"},
+		{"test", "Test1", "propFloat64", "double propFloat64"},
+		{"test", "Test1", "propString", "String propString"},
+		{"test", "Test1", "propBoolArray", "List<Boolean> propBoolArray"},
+		{"test", "Test1", "propIntArray", "List<Integer> propIntArray"},
+		{"test", "Test1", "propInt32Array", "List<Integer> propInt32Array"},
+		{"test", "Test1", "propInt64Array", "List<Long> propInt64Array"},
+		{"test", "Test1", "propFloatArray", "List<Float> propFloatArray"},
+		{"test", "Test1", "propFloat32Array", "List<Float> propFloat32Array"},
+		{"test", "Test1", "propFloat64Array", "List<Double> propFloat64Array"},
+		{"test", "Test1", "propStringArray", "List<String> propStringArray"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := javaListParam("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestListParamSymbols(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test2", "propEnum", "Enum1 propEnum"},
+		{"test", "Test2", "propStruct", "Struct1 propStruct"},
+		{"test", "Test2", "propInterface", "IInterface1 propInterface"},
+		{"test", "Test2", "propEnumArray", "List<Enum1> propEnumArray"},
+		{"test", "Test2", "propStructArray", "List<Struct1> propStructArray"},
+		{"test", "Test2", "propInterfaceArray", "List<IInterface1> propInterfaceArray"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := javaListParam("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}

--- a/pkg/gen/filters/filterjava/java_list_params.go
+++ b/pkg/gen/filters/filterjava/java_list_params.go
@@ -1,0 +1,23 @@
+package filterjava
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+func javaListParams(prefix string, nodes []*model.TypedNode) (string, error) {
+	if nodes == nil {
+		return "xxx", fmt.Errorf("javaListParams called with nil nodes")
+	}
+	var params []string
+	for _, p := range nodes {
+		r, err := ToListParamString(prefix, &p.Schema, p.Name)
+		if err != nil {
+			return "xxx", err
+		}
+		params = append(params, r)
+	}
+	return strings.Join(params, ", "), nil
+}

--- a/pkg/gen/filters/filterjava/java_list_params_test.go
+++ b/pkg/gen/filters/filterjava/java_list_params_test.go
@@ -1,0 +1,49 @@
+package filterjava
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListParams(t *testing.T) {
+	t.Parallel()
+	table := []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test3", "opBool", "boolean param1"},
+		{"test", "Test3", "opInt", "int param1"},
+		{"test", "Test3", "opInt32", "int param1"},
+		{"test", "Test3", "opInt64", "long param1"},
+		{"test", "Test3", "opFloat", "float param1"},
+		{"test", "Test3", "opFloat32", "float param1"},
+		{"test", "Test3", "opFloat64", "double param1"},
+		{"test", "Test3", "opString", "String param1"},
+		{"test", "Test3", "opBoolArray", "List<Boolean> param1"},
+		{"test", "Test3", "opIntArray", "List<Integer> param1"},
+		{"test", "Test3", "opInt32Array", "List<Integer> param1"},
+		{"test", "Test3", "opInt64Array", "List<Long> param1"},
+		{"test", "Test3", "opFloatArray", "List<Float> param1"},
+		{"test", "Test3", "opFloat32Array", "List<Float> param1"},
+		{"test", "Test3", "opFloat64Array", "List<Double> param1"},
+		{"test", "Test3", "opStringArray", "List<String> param1"},
+		{"test", "Test3", "op_Bool", "boolean param_Bool"},
+		{"test", "Test3", "op_bool", "boolean param_bool"},
+		{"test", "Test3", "op_1", "boolean param_1"},
+	}
+	syss := loadTestSystems(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.pn, func(t *testing.T) {
+				m := sys.LookupOperation(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, m)
+				r, err := javaListParams("", m.Params)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}

--- a/pkg/gen/filters/filterjava/java_list_return.go
+++ b/pkg/gen/filters/filterjava/java_list_return.go
@@ -1,0 +1,30 @@
+package filterjava
+
+import (
+	"fmt"
+
+	"github.com/apigear-io/cli/pkg/model"
+)
+
+func ToListReturnString(prefix string, schema *model.Schema) (string, error) {
+	if schema == nil {
+		return "xxx", fmt.Errorf("ToListReturnString schema is nil")
+	}
+	if !schema.IsArray {
+		return ToReturnString(prefix, schema)
+	}
+	inner := schema.InnerSchema()
+	elementType, err := ToReturnString(prefix, &inner)
+	if err != nil {
+		return "xxx", fmt.Errorf("javaListReturn element type error: %s", err)
+	}
+	boxed := toBoxedType(elementType)
+	return fmt.Sprintf("List<%s>", boxed), nil
+}
+
+func javaListReturn(prefix string, node *model.TypedNode) (string, error) {
+	if node == nil {
+		return "xxx", fmt.Errorf("javaListReturn node is nil")
+	}
+	return ToListReturnString(prefix, &node.Schema)
+}

--- a/pkg/gen/filters/filterjava/java_list_return_test.go
+++ b/pkg/gen/filters/filterjava/java_list_return_test.go
@@ -1,0 +1,144 @@
+package filterjava
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListReturn(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test1", "propVoid", "void"},
+		{"test", "Test1", "propBool", "boolean"},
+		{"test", "Test1", "propInt", "int"},
+		{"test", "Test1", "propInt32", "int"},
+		{"test", "Test1", "propInt64", "long"},
+		{"test", "Test1", "propFloat", "float"},
+		{"test", "Test1", "propFloat32", "float"},
+		{"test", "Test1", "propFloat64", "double"},
+		{"test", "Test1", "propString", "String"},
+		{"test", "Test1", "propBoolArray", "List<Boolean>"},
+		{"test", "Test1", "propIntArray", "List<Integer>"},
+		{"test", "Test1", "propInt32Array", "List<Integer>"},
+		{"test", "Test1", "propInt64Array", "List<Long>"},
+		{"test", "Test1", "propFloatArray", "List<Float>"},
+		{"test", "Test1", "propFloat32Array", "List<Float>"},
+		{"test", "Test1", "propFloat64Array", "List<Double>"},
+		{"test", "Test1", "propStringArray", "List<String>"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := javaListReturn("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestListOperationReturn(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test3", "opVoid", "void"},
+		{"test", "Test3", "opBool", "boolean"},
+		{"test", "Test3", "opInt", "int"},
+		{"test", "Test3", "opInt32", "int"},
+		{"test", "Test3", "opInt64", "long"},
+		{"test", "Test3", "opFloat", "float"},
+		{"test", "Test3", "opFloat32", "float"},
+		{"test", "Test3", "opFloat64", "double"},
+		{"test", "Test3", "opString", "String"},
+		{"test", "Test3", "opBoolArray", "List<Boolean>"},
+		{"test", "Test3", "opIntArray", "List<Integer>"},
+		{"test", "Test3", "opInt32Array", "List<Integer>"},
+		{"test", "Test3", "opInt64Array", "List<Long>"},
+		{"test", "Test3", "opFloatArray", "List<Float>"},
+		{"test", "Test3", "opFloat32Array", "List<Float>"},
+		{"test", "Test3", "opFloat64Array", "List<Double>"},
+		{"test", "Test3", "opStringArray", "List<String>"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				op := sys.LookupOperation(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, op)
+				r, err := javaListReturn("", op.Return)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestListReturnSymbols(t *testing.T) {
+	t.Parallel()
+	syss := loadTestSystems(t)
+	var propTests = []struct {
+		mn string
+		in string
+		pn string
+		rt string
+	}{
+		{"test", "Test2", "propEnum", "Enum1"},
+		{"test", "Test2", "propStruct", "Struct1"},
+		{"test", "Test2", "propInterface", "IInterface1"},
+		{"test", "Test2", "propEnumArray", "List<Enum1>"},
+		{"test", "Test2", "propStructArray", "List<Struct1>"},
+		{"test", "Test2", "propInterfaceArray", "List<IInterface1>"},
+	}
+	for _, sys := range syss {
+		for _, tt := range propTests {
+			t.Run(tt.pn, func(t *testing.T) {
+				prop := sys.LookupProperty(tt.mn, tt.in, tt.pn)
+				assert.NotNil(t, prop)
+				r, err := javaListReturn("", prop)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rt, r)
+			})
+		}
+	}
+}
+
+func TestListReturnExternsYaml(t *testing.T) {
+	t.Parallel()
+	table := []struct {
+		module_name    string
+		interface_name string
+		operation_name string
+		result         string
+	}{
+		{"test_apigear_next", "Iface1", "func1", "XType1"},
+		{"test_apigear_next", "Iface1", "func3", "demo.x.XType3A"},
+		{"test_apigear_next", "Iface1", "funcList", "List<demo.x.XType3A>"},
+		{"test_apigear_next", "Iface1", "funcImportedEnum", "test.test_api.Enum1"},
+		{"test_apigear_next", "Iface1", "funcImportedStruct", "test.test_api.Struct1"},
+	}
+	syss := loadExternSystemsYAML(t)
+	for _, sys := range syss {
+		for _, tt := range table {
+			t.Run(tt.operation_name, func(t *testing.T) {
+				op := sys.LookupOperation(tt.module_name, tt.interface_name, tt.operation_name)
+				assert.NotNil(t, op)
+				r, err := javaListReturn("", op.Return)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.result, r)
+			})
+		}
+	}
+}

--- a/pkg/gen/filters/filterjava/java_list_type.go
+++ b/pkg/gen/filters/filterjava/java_list_type.go
@@ -1,0 +1,3 @@
+package filterjava
+
+var javaListType = javaListReturn


### PR DESCRIPTION
## Summary
- Adds Java list variant template filters (list return, list param, list default, list async return, boxed type, list type)
- Rebased from PR #214 (alwa-siili/feat/add-java-list-filters) onto current main (v0.50.1)
- Fixed paths from `pkg/codegen/` to `pkg/gen/` and imports from `pkg/objmodel` to `pkg/model`

Supersedes #214

## Test plan
- [x] `go test ./pkg/gen/filters/filterjava/...` — all tests pass